### PR TITLE
Flag "isFile" has not always a valid value

### DIFF
--- a/QXlsx/source/xlsxzipreader.cpp
+++ b/QXlsx/source/xlsxzipreader.cpp
@@ -54,7 +54,7 @@ void ZipReader::init()
     QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
 #endif
     foreach (const QZipReader::FileInfo &fi, allFiles) {
-        if (fi.isFile)
+        if (fi.isFile || (!fi.isDir && !fi.isFile && !fi.isSymLink))
             m_filePaths.append(fi.filePath);
     }
 }


### PR DESCRIPTION
Neither 'Microsoft Office Professional Plus 2019' nor 'LibreOffice Ca…lc 6.3.2.2' write a valid flag for 'isFile'. Therefore we check if no flag is set and handle it as file.