### PR TITLE
Port back to qt4.8.7

### DIFF
--- a/QXlsx/header/xlsxabstractsheet_p.h
+++ b/QXlsx/header/xlsxabstractsheet_p.h
@@ -11,6 +11,7 @@
 
 #include "xlsxabstractsheet.h"
 #include "xlsxabstractooxmlfile_p.h"
+#include "xlsxdrawing_p.h"
 
 QT_BEGIN_NAMESPACE_XLSX
 

--- a/QXlsx/header/xlsxglobal.h
+++ b/QXlsx/header/xlsxglobal.h
@@ -21,5 +21,13 @@
 
 #define QXLSX_USE_NAMESPACE using namespace QXlsx;
 
+#if QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 )
+#undef QT_BEGIN_MOC_NAMESPACE
+#undef QT_END_MOC_NAMESPACE
+#define QT_BEGIN_MOC_NAMESPACE namespace QXlsx {
+#define QT_END_MOC_NAMESPACE }
+#define QStringLiteral QLatin1String
+#define Q_DECL_NOTHROW 
+#endif
 
 #endif // XLSXGLOBAL_H

--- a/QXlsx/header/xlsxworksheet_p.h
+++ b/QXlsx/header/xlsxworksheet_p.h
@@ -42,7 +42,11 @@
 #include <QVector>
 #include <QImage>
 #include <QSharedPointer>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
 
 #include "xlsxworksheet.h"
 #include "xlsxabstractsheet_p.h"
@@ -277,7 +281,11 @@ public:
     bool showOutlineSymbols;
     bool showWhiteSpace;
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     QRegularExpression urlPattern;
+#else
+    QRegExp urlPattern;
+#endif
 
 private:
 

--- a/QXlsx/source/xlsxcell.cpp
+++ b/QXlsx/source/xlsxcell.cpp
@@ -115,7 +115,6 @@ QVariant Cell::readValue() const
 	ret = d->value;
 
 	Format fmt = this->format();
-	int noFormatIndex = fmt.numberFormatIndex(); 
 
 	if (isDateTime())
 	{

--- a/QXlsx/source/xlsxcellreference.cpp
+++ b/QXlsx/source/xlsxcellreference.cpp
@@ -25,7 +25,12 @@
 #include "xlsxcellreference.h"
 #include <QStringList>
 #include <QMap>
+
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
 
 QT_BEGIN_NAMESPACE_XLSX
 
@@ -118,6 +123,7 @@ CellReference::CellReference(const char *cell)
 
 void CellReference::init(const QString &cell_str)
 {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     static QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
     QRegularExpressionMatch match = re.match(cell_str);
     if (match.hasMatch()) {
@@ -126,6 +132,16 @@ void CellReference::init(const QString &cell_str)
         _row = row_str.toInt();
         _column = col_from_name(col_str);
     }
+#else
+    QRegExp re(QLatin1String("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
+    if (re.indexIn(cell_str) != -1)
+    {
+       const QString col_str = re.cap(1);
+       const QString row_str = re.cap(2);
+       _row = row_str.toInt();
+       _column = col_from_name(col_str);
+    }
+#endif
 }
 
 /*!

--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -1245,7 +1245,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             if ( reader.name() == QLatin1String("axId") ) // mandatory element
             {
                 // dev57
-                uint axId = reader.attributes().value("val").toUInt(); // for Qt5.1
+                uint axId = reader.attributes().value("val").toString().toUInt(); // for Qt5.1
                 axis->axisId = axId;
             }
             else if ( reader.name() == QLatin1String("scaling") )
@@ -1314,7 +1314,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             else if ( reader.name() == QLatin1String("crossAx") ) // mandatory element
             {
                 // dev57
-                uint crossAx = reader.attributes().value(QLatin1String("val")).toUInt(); // for Qt5.1
+                uint crossAx = reader.attributes().value(QLatin1String("val")).toString().toUInt(); // for Qt5.1
                 axis->crossAx = crossAx;
             }
             else if ( reader.name() == QLatin1String("crosses") )

--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -1340,6 +1340,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
 
 bool ChartPrivate::loadXmlAxisEG_AxShared_Scaling(QXmlStreamReader &reader, XlsxAxis* axis)
 {
+    Q_UNUSED(axis);
     Q_ASSERT(reader.name() == QLatin1String("scaling"));
 
     while ( !reader.atEnd() )
@@ -1349,8 +1350,6 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Scaling(QXmlStreamReader &reader, Xlsx
         {
             if ( reader.name() == QLatin1String("orientation") )
             {
-                QString strOrientation = reader.attributes().value(QLatin1String("val")).toString();
-                int debugLine = 0;
             }
             else
             {
@@ -1437,6 +1436,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title(QXmlStreamReader &reader, XlsxAx
 
 bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Overlay(QXmlStreamReader &reader, XlsxAxis* axis)
 {
+    Q_UNUSED(axis);
     Q_ASSERT(reader.name() == QLatin1String("overlay"));
 
     while ( !reader.atEnd() )
@@ -1543,6 +1543,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P(QXmlStreamReader &read
 
 bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_pPr(QXmlStreamReader &reader, XlsxAxis* axis)
 {
+    Q_UNUSED(axis);
     Q_ASSERT(reader.name() == QLatin1String("pPr"));
 
     while ( !reader.atEnd() )
@@ -1552,8 +1553,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_pPr(QXmlStreamReader &
         {
             if ( reader.name() == QLatin1String("defRPr") )
             {
-                QString strDefRPr = reader.readElementText();
-                int debugLine = 0;
+                reader.readElementText();
             }
             else
             {

--- a/QXlsx/source/xlsxchartsheet.cpp
+++ b/QXlsx/source/xlsxchartsheet.cpp
@@ -106,10 +106,10 @@ void Chartsheet::saveToXmlFile(QIODevice *device) const
     writer.writeEndElement(); //sheetViews
 
     int idx = d->workbook->drawings().indexOf(d->drawing.data());
-    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
+    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("drawing"));
-    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
 
     writer.writeEndElement();//chartsheet
     writer.writeEndDocument();

--- a/QXlsx/source/xlsxcolor.cpp
+++ b/QXlsx/source/xlsxcolor.cpp
@@ -198,7 +198,7 @@ QDebug operator<<(QDebug dbg, const XlsxColor &c)
     else if (c.isIndexedColor())
         dbg.nospace() << "XlsxColor(indexed," << c.indexedColor() << ")";
     else if (c.isThemeColor())
-        dbg.nospace() << "XlsxColor(theme," << c.themeColor().join(QLatin1Char(':')) << ")";
+        dbg.nospace() << "XlsxColor(theme," << c.themeColor().join(QLatin1String(":")) << ")";
 
     return dbg.space();
 }

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -204,19 +204,19 @@ bool ConditionalFormatting::addHighlightCellsRule(HighlightRuleType type, const 
         if (type == Highlight_ContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("containsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("containsText");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
         } else if (type == Highlight_NotContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("notContainsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("notContains");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
         } else if (type == Highlight_BeginsWith) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("beginsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("beginsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         } else {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("endsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("endsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         }
         cfRule->attrs[XlsxCfRuleData::A_text] = formula1;
         skipFormula = true;
@@ -660,7 +660,7 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
     QStringList sqref;
     foreach (CellRange range, ranges())
         sqref.append(range.toString());
-    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1Char(' ')));
+    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
     for (int i=0; i<d->cfRules.size(); ++i) {
         const QSharedPointer<XlsxCfRuleData> &rule = d->cfRules[i];

--- a/QXlsx/source/xlsxcontenttypes.cpp
+++ b/QXlsx/source/xlsxcontenttypes.cpp
@@ -79,37 +79,37 @@ void ContentTypes::addWorkbook()
 
 void ContentTypes::addWorksheetName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.worksheet+xml"));
+    addOverride(QString("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.worksheet+xml"));
 }
 
 void ContentTypes::addChartsheetName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.chartsheet+xml"));
+    addOverride(QString("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.chartsheet+xml"));
 }
 
 void ContentTypes::addDrawingName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/drawings/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawing+xml"));
+    addOverride(QString("/xl/drawings/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawing+xml"));
 }
 
 void ContentTypes::addChartName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/charts/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawingml.chart+xml"));
+    addOverride(QString("/xl/charts/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawingml.chart+xml"));
 }
 
 void ContentTypes::addCommentName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.comments+xml"));
+    addOverride(QString("/xl/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.comments+xml"));
 }
 
 void ContentTypes::addTableName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/tables/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.table+xml"));
+    addOverride(QString("/xl/tables/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.table+xml"));
 }
 
 void ContentTypes::addExternalLinkName(const QString &name)
 {
-    addOverride(QStringLiteral("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.externalLink+xml"));
+    addOverride(QString("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.externalLink+xml"));
 }
 
 void ContentTypes::addSharedString()

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -444,7 +444,7 @@ bool DataValidation::saveToXml(QXmlStreamWriter &writer) const
     QStringList sqref;
     foreach (CellRange range, ranges())
         sqref.append(range.toString());
-    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1Char(' ')));
+    writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
     if (!formula1().isEmpty())
         writer.writeTextElement(QStringLiteral("formula1"), formula1());

--- a/QXlsx/source/xlsxdocument.cpp
+++ b/QXlsx/source/xlsxdocument.cpp
@@ -268,14 +268,14 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
     for (int i = 0 ; i < worksheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = worksheets[i];
-		contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
+		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QStringLiteral("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+		zipWriter.addFile(QString("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QStringLiteral("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+			zipWriter.addFile(QString("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	//save chartsheet xml files
@@ -285,25 +285,25 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
     for (int i=0; i<chartsheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = chartsheets[i];
-		contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
+		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QStringLiteral("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+		zipWriter.addFile(QString("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QStringLiteral("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+			zipWriter.addFile(QString("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save external links xml files
     for (int i=0; i<workbook->d_func()->externalLinks.count(); ++i)
     {
 		SimpleOOXmlFile *link = workbook->d_func()->externalLinks[i].data();
-		contentTypes->addExternalLinkName(QStringLiteral("externalLink%1").arg(i+1));
+		contentTypes->addExternalLinkName(QString("externalLink%1").arg(i+1));
 
-		zipWriter.addFile(QStringLiteral("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
+		zipWriter.addFile(QString("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
 		Relationships *rel = link->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QStringLiteral("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
+			zipWriter.addFile(QString("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save workbook xml file
@@ -314,12 +314,12 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save drawing xml files
     for (int i=0; i<workbook->drawings().size(); ++i)
     {
-		contentTypes->addDrawingName(QStringLiteral("drawing%1").arg(i+1));
+		contentTypes->addDrawingName(QString("drawing%1").arg(i+1));
 
 		Drawing *drawing = workbook->drawings()[i];
-		zipWriter.addFile(QStringLiteral("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
+		zipWriter.addFile(QString("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
 		if (!drawing->relationships()->isEmpty())
-			zipWriter.addFile(QStringLiteral("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
+			zipWriter.addFile(QString("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
 	}
 
 	// save docProps app/core xml file
@@ -353,9 +353,9 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save chart xml files
     for (int i=0; i<workbook->chartFiles().size(); ++i)
     {
-		contentTypes->addChartName(QStringLiteral("chart%1").arg(i+1));
+		contentTypes->addChartName(QString("chart%1").arg(i+1));
 		QSharedPointer<Chart> cf = workbook->chartFiles()[i];
-		zipWriter.addFile(QStringLiteral("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
+		zipWriter.addFile(QString("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
 	}
 
 	// save image files
@@ -365,7 +365,7 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 		if (!mf->mimeType().isEmpty())
 			contentTypes->addDefault(mf->suffix(), mf->mimeType());
 
-		zipWriter.addFile(QStringLiteral("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
+		zipWriter.addFile(QString("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
 	}
 
 	// save root .rels xml file

--- a/QXlsx/source/xlsxdrawinganchor.cpp
+++ b/QXlsx/source/xlsxdrawinganchor.cpp
@@ -620,7 +620,7 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvGraphicFramePr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id));
-    writer.writeAttribute(QStringLiteral("name"),QStringLiteral("Chart %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QString("Chart %1").arg(m_id));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvGraphicFramePr"));
     writer.writeEndElement();//xdr:nvGraphicFramePr
 
@@ -632,12 +632,12 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeAttribute(QStringLiteral("uri"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
 
     int idx = m_drawing->workbook->chartFiles().indexOf(m_chartFile);
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QStringLiteral("../charts/chart%1.xml").arg(idx+1));
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QString("../charts/chart%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("c:chart"));
     writer.writeAttribute(QStringLiteral("xmlns:c"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(m_drawing->relationships()->count()));
 
     writer.writeEndElement(); //a:graphicData
     writer.writeEndElement(); //a:graphic
@@ -658,7 +658,7 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvPicPr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id+1)); // liufeijin
-    writer.writeAttribute(QStringLiteral("name"), QStringLiteral("Picture %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QString("Picture %1").arg(m_id));
 
     writer.writeStartElement(QStringLiteral("xdr:cNvPicPr"));
     writer.writeEmptyElement(QStringLiteral("a:picLocks"));
@@ -667,14 +667,14 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
 
     writer.writeEndElement(); //xdr:nvPicPr
 
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2")
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2")
                                                      .arg(m_pictureFile->index()+1)
                                                      .arg(m_pictureFile->suffix()));
 
     writer.writeStartElement(QStringLiteral("xdr:blipFill"));
     writer.writeEmptyElement(QStringLiteral("a:blip"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:embed"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));
     writer.writeStartElement(QStringLiteral("a:stretch"));
     writer.writeEmptyElement(QStringLiteral("a:fillRect"));
     writer.writeEndElement(); //a:stretch
@@ -731,13 +731,13 @@ void DrawingAnchor::saveXmlObjectShape(QXmlStreamWriter &writer) const
         writer.writeEndElement(); //a:prstGeom
 
     if(!m_pictureFile.isNull()){
-        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
+        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
         writer.writeStartElement(QStringLiteral("a:blipFill"));
         writer.writeAttribute(QStringLiteral("dpi"), QString::number(dpiTA));
         writer.writeAttribute(QStringLiteral("rotWithShape"),QString::number(rotWithShapeTA));
 
          writer.writeStartElement(QStringLiteral("a:blip"));
-           writer.writeAttribute(QStringLiteral("r:embed"),QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
+           writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
            writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
            if(!sp_blip_cstate.isNull()){
              writer.writeAttribute(QStringLiteral("cstate"), sp_blip_cstate);

--- a/QXlsx/source/xlsxrelationships.cpp
+++ b/QXlsx/source/xlsxrelationships.cpp
@@ -92,7 +92,7 @@ QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 void Relationships::addRelationship(const QString &type, const QString &target, const QString &targetMode)
 {
     XlsxRelationship relation;
-    relation.id = QStringLiteral("rId%1").arg(m_relationships.size()+1);
+    relation.id = QString("rId%1").arg(m_relationships.size()+1);
     relation.type = type;
     relation.target = target;
     relation.targetMode = targetMode;

--- a/QXlsx/source/xlsxrichstring.cpp
+++ b/QXlsx/source/xlsxrichstring.cpp
@@ -329,7 +329,12 @@ bool operator !=(const QString &rs1, const RichString &rs2)
 
 uint qHash(const RichString &rs, uint seed) Q_DECL_NOTHROW
 {
-    return qHash(rs.d->idKey(), seed);
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+   return qHash(rs.d->idKey(), seed);
+#else
+   Q_UNUSED(seed);
+   return qHash(rs.d->idKey());
+#endif
 }
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -37,7 +37,13 @@ Styles::Styles(CreateFlag flag)
     //!Fix me. Should the custom num fmt Id starts with 164 or 176 or others??
 
     //!Fix me! Where should we put these register code?
-    if (QMetaType::type("XlsxColor") == QMetaType::UnknownType) {
+
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
+    if (QMetaType::type("XlsxColor") == QMetaType::UnknownType)
+#else
+    if (!QMetaType::isRegistered(QMetaType::type("XlsxColor")))
+#endif
+    {
         qRegisterMetaType<XlsxColor>("XlsxColor");
         qRegisterMetaTypeStreamOperators<XlsxColor>("XlsxColor");
 #if QT_VERSION >= 0x050200

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -998,7 +998,7 @@ bool Styles::readBorder(QXmlStreamReader &reader, Format &border)
 
 bool Styles::readCellStyleXfs(QXmlStreamReader &reader)
 {
-
+    Q_UNUSED(reader);
     return true;
 }
 

--- a/QXlsx/source/xlsxutility.cpp
+++ b/QXlsx/source/xlsxutility.cpp
@@ -27,7 +27,11 @@
 
 #include <QString>
 #include <QPoint>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
 #include <QMap>
 #include <QStringList>
 #include <QColor>
@@ -166,8 +170,13 @@ QString createSafeSheetName(const QString &nameProposal)
         ret = unescapeSheetName(ret);
 
     //Replace invalid chars with space.
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     if (nameProposal.contains(QRegularExpression(QStringLiteral("[/\\\\?*\\][:]"))))
         ret.replace(QRegularExpression(QStringLiteral("[/\\\\?*\\][:]")), QStringLiteral(" "));
+#else
+    if (nameProposal.contains(QRegExp(QLatin1String("[/\\\\?*\\][:]"))))
+        ret.replace(QRegExp(QLatin1String("[/\\\\?*\\][:]")), QLatin1String(" "));
+#endif
     if (ret.startsWith(QLatin1Char('\'')))
         ret[0] = QLatin1Char(' ');
     if (ret.endsWith(QLatin1Char('\'')))
@@ -187,8 +196,13 @@ QString escapeSheetName(const QString &sheetName)
     Q_ASSERT(!sheetName.startsWith(QLatin1Char('\'')) && !sheetName.endsWith(QLatin1Char('\'')));
 
     //These is no need to escape
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     if (!sheetName.contains(QRegularExpression(QStringLiteral("[ +\\-,%^=<>'&]"))))
         return sheetName;
+#else
+    if (!sheetName.contains(QRegExp(QLatin1String("[ +\\-,%^=<>'&]"))))
+        return sheetName;
+#endif
 
     //OK, escape is needed.
     QString name = sheetName;

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -230,12 +230,12 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
         if (type == AbstractSheet::ST_WorkSheet) {
             do {
                 ++d->last_worksheet_index;
-                sheetName = QStringLiteral("Sheet%1").arg(d->last_worksheet_index);
+                sheetName = QString("Sheet%1").arg(d->last_worksheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else if (type == AbstractSheet::ST_ChartSheet) {
             do {
                 ++d->last_chartsheet_index;
-                sheetName = QStringLiteral("Chart%1").arg(d->last_chartsheet_index);
+                sheetName = QString("Chart%1").arg(d->last_chartsheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else {
             qWarning("unsupported sheet type.");
@@ -364,7 +364,7 @@ bool Workbook::copySheet(int index, const QString &newName)
         int copy_index = 1;
         do {
             ++copy_index;
-            worksheetName = QStringLiteral("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
+            worksheetName = QString("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
         } while (d->sheetNames.contains(worksheetName));
     }
 
@@ -501,11 +501,11 @@ void Workbook::saveToXmlFile(QIODevice *device) const
             writer.writeAttribute(QStringLiteral("state"), QStringLiteral("veryHidden"));
 
         if (sheet->sheetType() == AbstractSheet::ST_WorkSheet)
-            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QStringLiteral("worksheets/sheet%1.xml").arg(++worksheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QString("worksheets/sheet%1.xml").arg(++worksheetIndex));
         else
-            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QStringLiteral("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QString("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
 
-        writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
+        writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
     }
     writer.writeEndElement();//sheets
 
@@ -513,8 +513,8 @@ void Workbook::saveToXmlFile(QIODevice *device) const
         writer.writeStartElement(QStringLiteral("externalReferences"));
         for (int i=0; i<d->externalLinks.size(); ++i) {
             writer.writeEmptyElement(QStringLiteral("externalReference"));
-            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QStringLiteral("externalLinks/externalLink%1.xml").arg(i+1));
-            writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
+            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QString("externalLinks/externalLink%1.xml").arg(i+1));
+            writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
         }
         writer.writeEndElement();//externalReferences
     }

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -11,6 +11,7 @@
 #include "xlsxformat_p.h"
 #include "xlsxmediafile_p.h"
 #include "xlsxutility_p.h"
+#include "xlsxchart.h"
 
 #include <QXmlStreamWriter>
 #include <QXmlStreamReader>

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -1547,7 +1547,6 @@ void WorksheetPrivate::saveXmlCellData(QXmlStreamWriter &writer, int row, int co
     {
         if (cell->hasFormula())
         {
-            int si = cell->formula().d->si;
             QString strFormula = cell->formula().d->formula;
 
             cell->formula().saveToXml(writer);
@@ -1575,7 +1574,6 @@ void WorksheetPrivate::saveXmlCellData(QXmlStreamWriter &writer, int row, int co
 
         if (cell->hasFormula())
         {
-            int si = cell->formula().d->si;
             QString strFormula = cell->formula().d->formula;
 
             cell->formula().saveToXml(writer);
@@ -1676,7 +1674,6 @@ void WorksheetPrivate::saveXmlCellData(QXmlStreamWriter &writer, int row, int co
 
         if (cell->hasFormula())
         {
-            int si = cell->formula().d->si;
             QString strFormula = cell->formula().d->formula;
 
             cell->formula().saveToXml(writer);

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -115,7 +115,7 @@ void WorksheetPrivate::calculateSpans() const
 
 		if (row_num%16 == 0 || row_num == dimension.lastRow()) {
 			if (span_max != -1) {
-				row_spans[row_num / 16] = QStringLiteral("%1:%2").arg(span_min).arg(span_max);
+				row_spans[row_num / 16] = QString("%1:%2").arg(span_min).arg(span_max);
 				span_min = XLSX_COLUMN_MAX+1;
 				span_max = -1;
 			}
@@ -1751,7 +1751,7 @@ void WorksheetPrivate::saveXmlHyperlinks(QXmlStreamWriter &writer) const
                 // Update relationships
 				relationships->addWorksheetRelationship(QStringLiteral("/hyperlink"), data->target, QStringLiteral("External"));
 
-				writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
+				writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
 			}
 
 			if (!data->location.isEmpty())
@@ -1783,10 +1783,10 @@ void WorksheetPrivate::saveXmlDrawings(QXmlStreamWriter &writer) const
 		return;
 
 	int idx = workbook->drawings().indexOf(drawing.data());
-	relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
+	relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
 
 	writer.writeEmptyElement(QStringLiteral("drawing"));
-	writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
+	writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
 }
 
 void WorksheetPrivate::splitColsInfo(int colFirst, int colLast)

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -8,7 +8,6 @@
 #include <QPoint>
 #include <QFile>
 #include <QUrl>
-#include <QRegularExpression>
 #include <QDebug>
 #include <QBuffer>
 #include <QXmlStreamWriter>

--- a/TestEnv.md
+++ b/TestEnv.md
@@ -19,7 +19,7 @@
 | 5.5.1  | MingW              | Windows 32bit             | :smile: |
 | 5.5.0  | gcc+make           | Ubuntu 17/i686            | :smile: |
 | 5.2.0  | gcc+make           | Ubuntu 14/x64             | :smile: |
-| 5.0.1  | MingW              | Windows 32bit             | :smile: |
+| ~~5.0.1~~  | ~~MingW~~              | ~~Windows 32bit~~             | ~~:angry:~~ |
 
 - As the code is upgraded, old Qt may not be supported.
 - If more funding is raised, we will also support MacOS testing.


### PR DESCRIPTION
Thanks for your great work!. 

We are still using Qt 4.8.7 so we had to port your library back to this old version. In Qt 4 there is not QStringLiteral class. Our replacement is QLatin1String when possible or QString as alternative if ```arg()``` was used.

Feel free to accept this request if you like.
