### PR TITLE
feat: support multithread tasks

### DIFF
--- a/QXlsx/QXlsx.pri
+++ b/QXlsx/QXlsx.pri
@@ -1,4 +1,4 @@
-# QXlsx.pri 
+# QXlsx.pri
 
 QT += core
 QT += gui-private
@@ -16,7 +16,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 isEmpty(QXLSX_PARENTPATH) {
     message( 'QXLSX_PARENTPATH is empty. use default value.' )
-    QXLSX_PARENTPATH = ../
+    QXLSX_PARENTPATH = $$PWD/../
 } else {
     message( 'QXLSX_PARENTPATH is not empty.' )
     message( $${QXLSX_PARENTPATH} )
@@ -24,7 +24,7 @@ isEmpty(QXLSX_PARENTPATH) {
 
 isEmpty(QXLSX_HEADERPATH) {
     message( 'QXLSX_HEADERPATH is empty. use default value.' )
-    QXLSX_HEADERPATH = ../QXlsx/header/
+    QXLSX_HEADERPATH = $$PWD/../QXlsx/header/
 } else {
     message( 'QXLSX_HEADERPATH is not empty.' )
     message( $${QXLSX_HEADERPATH} )
@@ -32,13 +32,13 @@ isEmpty(QXLSX_HEADERPATH) {
 
 isEmpty(QXLSX_SOURCEPATH) {
     message( 'QXLSX_SOURCEPATH is empty. use default value.' )
-    QXLSX_SOURCEPATH = ../QXlsx/source/
+    QXLSX_SOURCEPATH = $$PWD/../QXlsx/source/
 } else {
     message( 'QXLSX_SOURCEPATH is not empty.' )
     message( $${QXLSX_SOURCEPATH} )
 }
 
-INCLUDEPATH += .
+INCLUDEPATH += $$PWD
 INCLUDEPATH += $${QXLSX_PARENTPATH}
 INCLUDEPATH += $${QXLSX_HEADERPATH}
 

--- a/QXlsx/QXlsx.pro
+++ b/QXlsx/QXlsx.pro
@@ -24,9 +24,9 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-QXLSX_PARENTPATH=./
-QXLSX_HEADERPATH=./header/
-QXLSX_SOURCEPATH=./source/
-include(./QXlsx.pri)
+QXLSX_PARENTPATH=$$PWD/
+QXLSX_HEADERPATH=$$PWD/header/
+QXLSX_SOURCEPATH=$$PWD/source/
+include($$PWD/QXlsx.pri)
 
 

--- a/QXlsx/source/xlsxcellreference.cpp
+++ b/QXlsx/source/xlsxcellreference.cpp
@@ -48,7 +48,7 @@ int intPow(int x, int p)
 
 QString col_to_name(int col_num)
 {
-    static QMap<int, QString> col_cache;
+    static thread_local QMap<int, QString> col_cache;
 
     if (!col_cache.contains(col_num)) {
         QString col_str;
@@ -124,7 +124,7 @@ CellReference::CellReference(const char *cell)
 void CellReference::init(const QString &cell_str)
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
-    static QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
+    static thread_local QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
     QRegularExpressionMatch match = re.match(cell_str);
     if (match.hasMatch()) {
         const QString col_str = match.captured(1);

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -390,32 +390,33 @@ void DataValidation::addRange(const CellRange &range)
  */
 bool DataValidation::saveToXml(QXmlStreamWriter &writer) const
 {
-    static QMap<DataValidation::ValidationType, QString> typeMap;
-    static QMap<DataValidation::ValidationOperator, QString> opMap;
-    static QMap<DataValidation::ErrorStyle, QString> esMap;
-    if (typeMap.isEmpty()) {
-        typeMap.insert(DataValidation::None, QStringLiteral("none"));
-        typeMap.insert(DataValidation::Whole, QStringLiteral("whole"));
-        typeMap.insert(DataValidation::Decimal, QStringLiteral("decimal"));
-        typeMap.insert(DataValidation::List, QStringLiteral("list"));
-        typeMap.insert(DataValidation::Date, QStringLiteral("date"));
-        typeMap.insert(DataValidation::Time, QStringLiteral("time"));
-        typeMap.insert(DataValidation::TextLength, QStringLiteral("textLength"));
-        typeMap.insert(DataValidation::Custom, QStringLiteral("custom"));
+    static const QMap<DataValidation::ValidationType, QString> typeMap = {
+        {DataValidation::None, QStringLiteral("none")},
+        {DataValidation::Whole, QStringLiteral("whole")},
+        {DataValidation::Decimal, QStringLiteral("decimal")},
+        {DataValidation::List, QStringLiteral("list")},
+        {DataValidation::Date, QStringLiteral("date")},
+        {DataValidation::Time, QStringLiteral("time")},
+        {DataValidation::TextLength, QStringLiteral("textLength")},
+        {DataValidation::Custom, QStringLiteral("custom")}
+    };
 
-        opMap.insert(DataValidation::Between, QStringLiteral("between"));
-        opMap.insert(DataValidation::NotBetween, QStringLiteral("notBetween"));
-        opMap.insert(DataValidation::Equal, QStringLiteral("equal"));
-        opMap.insert(DataValidation::NotEqual, QStringLiteral("notEqual"));
-        opMap.insert(DataValidation::LessThan, QStringLiteral("lessThan"));
-        opMap.insert(DataValidation::LessThanOrEqual, QStringLiteral("lessThanOrEqual"));
-        opMap.insert(DataValidation::GreaterThan, QStringLiteral("greaterThan"));
-        opMap.insert(DataValidation::GreaterThanOrEqual, QStringLiteral("greaterThanOrEqual"));
+    static const QMap<DataValidation::ValidationOperator, QString> opMap = {
+        {DataValidation::Between, QStringLiteral("between")},
+        {DataValidation::NotBetween, QStringLiteral("notBetween")},
+        {DataValidation::Equal, QStringLiteral("equal")},
+        {DataValidation::NotEqual, QStringLiteral("notEqual")},
+        {DataValidation::LessThan, QStringLiteral("lessThan")},
+        {DataValidation::LessThanOrEqual, QStringLiteral("lessThanOrEqual")},
+        {DataValidation::GreaterThan, QStringLiteral("greaterThan")},
+        {DataValidation::GreaterThanOrEqual, QStringLiteral("greaterThanOrEqual")}
+    };
 
-        esMap.insert(DataValidation::Stop, QStringLiteral("stop"));
-        esMap.insert(DataValidation::Warning, QStringLiteral("warning"));
-        esMap.insert(DataValidation::Information, QStringLiteral("information"));
-    }
+    static const QMap<DataValidation::ErrorStyle, QString> esMap = {
+        {DataValidation::Stop, QStringLiteral("stop")},
+        {DataValidation::Warning, QStringLiteral("warning")},
+        {DataValidation::Information, QStringLiteral("information")}
+    };
 
     writer.writeStartElement(QStringLiteral("dataValidation"));
     if (validationType() != DataValidation::None)
@@ -463,32 +464,33 @@ DataValidation DataValidation::loadFromXml(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("dataValidation"));
 
-    static QMap<QString, DataValidation::ValidationType> typeMap;
-    static QMap<QString, DataValidation::ValidationOperator> opMap;
-    static QMap<QString, DataValidation::ErrorStyle> esMap;
-    if (typeMap.isEmpty()) {
-        typeMap.insert(QStringLiteral("none"), DataValidation::None);
-        typeMap.insert(QStringLiteral("whole"), DataValidation::Whole);
-        typeMap.insert(QStringLiteral("decimal"), DataValidation::Decimal);
-        typeMap.insert(QStringLiteral("list"), DataValidation::List);
-        typeMap.insert(QStringLiteral("date"), DataValidation::Date);
-        typeMap.insert(QStringLiteral("time"), DataValidation::Time);
-        typeMap.insert(QStringLiteral("textLength"), DataValidation::TextLength);
-        typeMap.insert(QStringLiteral("custom"), DataValidation::Custom);
+    static const QMap<QString, DataValidation::ValidationType> typeMap = {
+        {QStringLiteral("none"), DataValidation::None},
+        {QStringLiteral("whole"), DataValidation::Whole},
+        {QStringLiteral("decimal"), DataValidation::Decimal},
+        {QStringLiteral("list"), DataValidation::List},
+        {QStringLiteral("date"), DataValidation::Date},
+        {QStringLiteral("time"), DataValidation::Time},
+        {QStringLiteral("textLength"), DataValidation::TextLength},
+        {QStringLiteral("custom"), DataValidation::Custom}
+    };
 
-        opMap.insert(QStringLiteral("between"), DataValidation::Between);
-        opMap.insert(QStringLiteral("notBetween"), DataValidation::NotBetween);
-        opMap.insert(QStringLiteral("equal"), DataValidation::Equal);
-        opMap.insert(QStringLiteral("notEqual"), DataValidation::NotEqual);
-        opMap.insert(QStringLiteral("lessThan"), DataValidation::LessThan);
-        opMap.insert(QStringLiteral("lessThanOrEqual"), DataValidation::LessThanOrEqual);
-        opMap.insert(QStringLiteral("greaterThan"), DataValidation::GreaterThan);
-        opMap.insert(QStringLiteral("greaterThanOrEqual"), DataValidation::GreaterThanOrEqual);
+    static const QMap<QString, DataValidation::ValidationOperator> opMap = {
+        {QStringLiteral("between"), DataValidation::Between},
+        {QStringLiteral("notBetween"), DataValidation::NotBetween},
+        {QStringLiteral("equal"), DataValidation::Equal},
+        {QStringLiteral("notEqual"), DataValidation::NotEqual},
+        {QStringLiteral("lessThan"), DataValidation::LessThan},
+        {QStringLiteral("lessThanOrEqual"), DataValidation::LessThanOrEqual},
+        {QStringLiteral("greaterThan"), DataValidation::GreaterThan},
+        {QStringLiteral("greaterThanOrEqual"), DataValidation::GreaterThanOrEqual}
+    };
 
-        esMap.insert(QStringLiteral("stop"), DataValidation::Stop);
-        esMap.insert(QStringLiteral("warning"), DataValidation::Warning);
-        esMap.insert(QStringLiteral("information"), DataValidation::Information);
-    }
+    static const QMap<QString, DataValidation::ErrorStyle> esMap = {
+        {QStringLiteral("stop"), DataValidation::Stop},
+        {QStringLiteral("warning"), DataValidation::Warning},
+        {QStringLiteral("information"), DataValidation::Information}
+    };
 
     DataValidation validation;
     QXmlStreamAttributes attrs = reader.attributes();

--- a/QXlsx/source/xlsxdocpropsapp.cpp
+++ b/QXlsx/source/xlsxdocpropsapp.cpp
@@ -51,10 +51,9 @@ void DocPropsApp::addHeadingPair(const QString &name, int value)
 
 bool DocPropsApp::setProperty(const QString &name, const QString &value)
 {
-    static QStringList validKeys;
-    if (validKeys.isEmpty()) {
-        validKeys << QStringLiteral("manager") << QStringLiteral("company");
-    }
+    static const QStringList validKeys = {
+        QStringLiteral("manager"), QStringLiteral("company")
+    };
 
     if (!validKeys.contains(name))
         return false;

--- a/QXlsx/source/xlsxdocpropscore.cpp
+++ b/QXlsx/source/xlsxdocpropscore.cpp
@@ -41,13 +41,12 @@ DocPropsCore::DocPropsCore(CreateFlag flag)
 
 bool DocPropsCore::setProperty(const QString &name, const QString &value)
 {
-    static QStringList validKeys;
-    if (validKeys.isEmpty()) {
-        validKeys << QStringLiteral("title") << QStringLiteral("subject")
-                  << QStringLiteral("keywords") << QStringLiteral("description")
-                  << QStringLiteral("category") << QStringLiteral("status")
-                  << QStringLiteral("created") << QStringLiteral("creator");
-    }
+    static const QStringList validKeys = {
+        QStringLiteral("title"), QStringLiteral("subject"),
+        QStringLiteral("keywords"), QStringLiteral("description"),
+        QStringLiteral("category"), QStringLiteral("status"),
+        QStringLiteral("created"), QStringLiteral("creator")
+    };
 
     if (!validKeys.contains(name))
         return false;

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -1,4 +1,4 @@
-// xlsxstyles.cpp 
+// xlsxstyles.cpp
 
 #include "xlsxstyles_p.h"
 #include "xlsxformat_p.h"
@@ -475,28 +475,27 @@ void Styles::writeFills(QXmlStreamWriter &writer) const
 
 void Styles::writeFill(QXmlStreamWriter &writer, const Format &fill, bool isDxf) const
 {
-    static QMap<int, QString> patternStrings;
-    if (patternStrings.isEmpty()) {
-        patternStrings[Format::PatternNone] = QStringLiteral("none");
-        patternStrings[Format::PatternSolid] = QStringLiteral("solid");
-        patternStrings[Format::PatternMediumGray] = QStringLiteral("mediumGray");
-        patternStrings[Format::PatternDarkGray] = QStringLiteral("darkGray");
-        patternStrings[Format::PatternLightGray] = QStringLiteral("lightGray");
-        patternStrings[Format::PatternDarkHorizontal] = QStringLiteral("darkHorizontal");
-        patternStrings[Format::PatternDarkVertical] = QStringLiteral("darkVertical");
-        patternStrings[Format::PatternDarkDown] = QStringLiteral("darkDown");
-        patternStrings[Format::PatternDarkUp] = QStringLiteral("darkUp");
-        patternStrings[Format::PatternDarkGrid] = QStringLiteral("darkGrid");
-        patternStrings[Format::PatternDarkTrellis] = QStringLiteral("darkTrellis");
-        patternStrings[Format::PatternLightHorizontal] = QStringLiteral("lightHorizontal");
-        patternStrings[Format::PatternLightVertical] = QStringLiteral("lightVertical");
-        patternStrings[Format::PatternLightDown] = QStringLiteral("lightDown");
-        patternStrings[Format::PatternLightUp] = QStringLiteral("lightUp");
-        patternStrings[Format::PatternLightTrellis] = QStringLiteral("lightTrellis");
-        patternStrings[Format::PatternGray125] = QStringLiteral("gray125");
-        patternStrings[Format::PatternGray0625] = QStringLiteral("gray0625");
-        patternStrings[Format::PatternLightGrid] = QStringLiteral("lightGrid");
-    }
+    static const QMap<int, QString> patternStrings = {
+        {Format::PatternNone, QStringLiteral("none")},
+        {Format::PatternSolid, QStringLiteral("solid")},
+        {Format::PatternMediumGray, QStringLiteral("mediumGray")},
+        {Format::PatternDarkGray, QStringLiteral("darkGray")},
+        {Format::PatternLightGray, QStringLiteral("lightGray")},
+        {Format::PatternDarkHorizontal, QStringLiteral("darkHorizontal")},
+        {Format::PatternDarkVertical, QStringLiteral("darkVertical")},
+        {Format::PatternDarkDown, QStringLiteral("darkDown")},
+        {Format::PatternDarkUp, QStringLiteral("darkUp")},
+        {Format::PatternDarkGrid, QStringLiteral("darkGrid")},
+        {Format::PatternDarkTrellis, QStringLiteral("darkTrellis")},
+        {Format::PatternLightHorizontal, QStringLiteral("lightHorizontal")},
+        {Format::PatternLightVertical, QStringLiteral("lightVertical")},
+        {Format::PatternLightDown, QStringLiteral("lightDown")},
+        {Format::PatternLightUp, QStringLiteral("lightUp")},
+        {Format::PatternLightTrellis, QStringLiteral("lightTrellis")},
+        {Format::PatternGray125, QStringLiteral("gray125")},
+        {Format::PatternGray0625, QStringLiteral("gray0625")},
+        {Format::PatternLightGrid, QStringLiteral("lightGrid")}
+    };
 
     writer.writeStartElement(QStringLiteral("fill"));
     writer.writeStartElement(QStringLiteral("patternFill"));
@@ -570,23 +569,22 @@ void Styles::writeSubBorder(QXmlStreamWriter &writer, const QString &type, int s
         return;
     }
 
-    static QMap<int, QString> stylesString;
-    if (stylesString.isEmpty()) {
-        stylesString[Format::BorderNone] = QStringLiteral("none");
-        stylesString[Format::BorderThin] = QStringLiteral("thin");
-        stylesString[Format::BorderMedium] = QStringLiteral("medium");
-        stylesString[Format::BorderDashed] = QStringLiteral("dashed");
-        stylesString[Format::BorderDotted] = QStringLiteral("dotted");
-        stylesString[Format::BorderThick] = QStringLiteral("thick");
-        stylesString[Format::BorderDouble] = QStringLiteral("double");
-        stylesString[Format::BorderHair] = QStringLiteral("hair");
-        stylesString[Format::BorderMediumDashed] = QStringLiteral("mediumDashed");
-        stylesString[Format::BorderDashDot] = QStringLiteral("dashDot");
-        stylesString[Format::BorderMediumDashDot] = QStringLiteral("mediumDashDot");
-        stylesString[Format::BorderDashDotDot] = QStringLiteral("dashDotDot");
-        stylesString[Format::BorderMediumDashDotDot] = QStringLiteral("mediumDashDotDot");
-        stylesString[Format::BorderSlantDashDot] = QStringLiteral("slantDashDot");
-    }
+    static const QMap<int, QString> stylesString = {
+        {Format::BorderNone, QStringLiteral("none")},
+        {Format::BorderThin, QStringLiteral("thin")},
+        {Format::BorderMedium, QStringLiteral("medium")},
+        {Format::BorderDashed, QStringLiteral("dashed")},
+        {Format::BorderDotted, QStringLiteral("dotted")},
+        {Format::BorderThick, QStringLiteral("thick")},
+        {Format::BorderDouble, QStringLiteral("double")},
+        {Format::BorderHair, QStringLiteral("hair")},
+        {Format::BorderMediumDashed, QStringLiteral("mediumDashed")},
+        {Format::BorderDashDot, QStringLiteral("dashDot")},
+        {Format::BorderMediumDashDot, QStringLiteral("mediumDashDot")},
+        {Format::BorderDashDotDot, QStringLiteral("dashDotDot")},
+        {Format::BorderMediumDashDotDot, QStringLiteral("mediumDashDotDot")},
+        {Format::BorderSlantDashDot, QStringLiteral("slantDashDot")}
+    };
 
     writer.writeStartElement(type);
     writer.writeAttribute(QStringLiteral("style"), stylesString[style]);
@@ -884,28 +882,27 @@ bool Styles::readFill(QXmlStreamReader &reader, Format &fill)
 {
     Q_ASSERT(reader.name() == QLatin1String("fill"));
 
-    static QMap<QString, Format::FillPattern> patternValues;
-    if (patternValues.isEmpty()) {
-        patternValues[QStringLiteral("none")] = Format::PatternNone;
-        patternValues[QStringLiteral("solid")] = Format::PatternSolid;
-        patternValues[QStringLiteral("mediumGray")] = Format::PatternMediumGray;
-        patternValues[QStringLiteral("darkGray")] = Format::PatternDarkGray;
-        patternValues[QStringLiteral("lightGray")] = Format::PatternLightGray;
-        patternValues[QStringLiteral("darkHorizontal")] = Format::PatternDarkHorizontal;
-        patternValues[QStringLiteral("darkVertical")] = Format::PatternDarkVertical;
-        patternValues[QStringLiteral("darkDown")] = Format::PatternDarkDown;
-        patternValues[QStringLiteral("darkUp")] = Format::PatternDarkUp;
-        patternValues[QStringLiteral("darkGrid")] = Format::PatternDarkGrid;
-        patternValues[QStringLiteral("darkTrellis")] = Format::PatternDarkTrellis;
-        patternValues[QStringLiteral("lightHorizontal")] = Format::PatternLightHorizontal;
-        patternValues[QStringLiteral("lightVertical")] = Format::PatternLightVertical;
-        patternValues[QStringLiteral("lightDown")] = Format::PatternLightDown;
-        patternValues[QStringLiteral("lightUp")] = Format::PatternLightUp;
-        patternValues[QStringLiteral("lightTrellis")] = Format::PatternLightTrellis;
-        patternValues[QStringLiteral("gray125")] = Format::PatternGray125;
-        patternValues[QStringLiteral("gray0625")] = Format::PatternGray0625;
-        patternValues[QStringLiteral("lightGrid")] = Format::PatternLightGrid;
-    }
+    static const QMap<QString, Format::FillPattern> patternValues = {
+        {QStringLiteral("none"), Format::PatternNone},
+        {QStringLiteral("solid"), Format::PatternSolid},
+        {QStringLiteral("mediumGray"), Format::PatternMediumGray},
+        {QStringLiteral("darkGray"), Format::PatternDarkGray},
+        {QStringLiteral("lightGray"), Format::PatternLightGray},
+        {QStringLiteral("darkHorizontal"), Format::PatternDarkHorizontal},
+        {QStringLiteral("darkVertical"), Format::PatternDarkVertical},
+        {QStringLiteral("darkDown"), Format::PatternDarkDown},
+        {QStringLiteral("darkUp"), Format::PatternDarkUp},
+        {QStringLiteral("darkGrid"), Format::PatternDarkGrid},
+        {QStringLiteral("darkTrellis"), Format::PatternDarkTrellis},
+        {QStringLiteral("lightHorizontal"), Format::PatternLightHorizontal},
+        {QStringLiteral("lightVertical"), Format::PatternLightVertical},
+        {QStringLiteral("lightDown"), Format::PatternLightDown},
+        {QStringLiteral("lightUp"), Format::PatternLightUp},
+        {QStringLiteral("lightTrellis"), Format::PatternLightTrellis},
+        {QStringLiteral("gray125"), Format::PatternGray125},
+        {QStringLiteral("gray0625"), Format::PatternGray0625},
+        {QStringLiteral("lightGrid"), Format::PatternLightGrid}
+    };
 
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement && reader.name() == QLatin1String("fill"))) {
         reader.readNextStartElement();
@@ -1045,23 +1042,22 @@ bool Styles::readSubBorder(QXmlStreamReader &reader, const QString &name, Format
 {
     Q_ASSERT(reader.name() == name);
 
-    static QMap<QString, Format::BorderStyle> stylesStringsMap;
-    if (stylesStringsMap.isEmpty()) {
-        stylesStringsMap[QStringLiteral("none")] = Format::BorderNone;
-        stylesStringsMap[QStringLiteral("thin")] = Format::BorderThin;
-        stylesStringsMap[QStringLiteral("medium")] = Format::BorderMedium;
-        stylesStringsMap[QStringLiteral("dashed")] = Format::BorderDashed;
-        stylesStringsMap[QStringLiteral("dotted")] = Format::BorderDotted;
-        stylesStringsMap[QStringLiteral("thick")] = Format::BorderThick;
-        stylesStringsMap[QStringLiteral("double")] = Format::BorderDouble;
-        stylesStringsMap[QStringLiteral("hair")] = Format::BorderHair;
-        stylesStringsMap[QStringLiteral("mediumDashed")] = Format::BorderMediumDashed;
-        stylesStringsMap[QStringLiteral("dashDot")] = Format::BorderDashDot;
-        stylesStringsMap[QStringLiteral("mediumDashDot")] = Format::BorderMediumDashDot;
-        stylesStringsMap[QStringLiteral("dashDotDot")] = Format::BorderDashDotDot;
-        stylesStringsMap[QStringLiteral("mediumDashDotDot")] = Format::BorderMediumDashDotDot;
-        stylesStringsMap[QStringLiteral("slantDashDot")] = Format::BorderSlantDashDot;
-    }
+    static const QMap<QString, Format::BorderStyle> stylesStringsMap = {
+        {QStringLiteral("none"), Format::BorderNone},
+        {QStringLiteral("thin"), Format::BorderThin},
+        {QStringLiteral("medium"), Format::BorderMedium},
+        {QStringLiteral("dashed"), Format::BorderDashed},
+        {QStringLiteral("dotted"), Format::BorderDotted},
+        {QStringLiteral("thick"), Format::BorderThick},
+        {QStringLiteral("double"), Format::BorderDouble},
+        {QStringLiteral("hair"), Format::BorderHair},
+        {QStringLiteral("mediumDashed"), Format::BorderMediumDashed},
+        {QStringLiteral("dashDot"), Format::BorderDashDot},
+        {QStringLiteral("mediumDashDot"), Format::BorderMediumDashDot},
+        {QStringLiteral("dashDotDot"), Format::BorderDashDotDot},
+        {QStringLiteral("mediumDashDotDot"), Format::BorderMediumDashDotDot},
+        {QStringLiteral("slantDashDot"), Format::BorderSlantDashDot}
+    };
 
     QXmlStreamAttributes attributes = reader.attributes();
     if (attributes.hasAttribute(QLatin1String("style"))) {
@@ -1176,28 +1172,26 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                         QXmlStreamAttributes alignAttrs = reader.attributes();
 
                         if (alignAttrs.hasAttribute(QLatin1String("horizontal"))) {
-                            static QMap<QString, Format::HorizontalAlignment> alignStringMap;
-                            if (alignStringMap.isEmpty()) {
-                                alignStringMap.insert(QStringLiteral("left"), Format::AlignLeft);
-                                alignStringMap.insert(QStringLiteral("center"), Format::AlignHCenter);
-                                alignStringMap.insert(QStringLiteral("right"), Format::AlignRight);
-                                alignStringMap.insert(QStringLiteral("justify"), Format::AlignHJustify);
-                                alignStringMap.insert(QStringLiteral("centerContinuous"), Format::AlignHMerge);
-                                alignStringMap.insert(QStringLiteral("distributed"), Format::AlignHDistributed);
-                            }
+                            static const QMap<QString, Format::HorizontalAlignment> alignStringMap = {
+                                {QStringLiteral("left"), Format::AlignLeft},
+                                {QStringLiteral("center"), Format::AlignHCenter},
+                                {QStringLiteral("right"), Format::AlignRight},
+                                {QStringLiteral("justify"), Format::AlignHJustify},
+                                {QStringLiteral("centerContinuous"), Format::AlignHMerge},
+                                {QStringLiteral("distributed"), Format::AlignHDistributed}
+                            };
                             QString str = alignAttrs.value(QLatin1String("horizontal")).toString();
                             if (alignStringMap.contains(str))
                                 format.setHorizontalAlignment(alignStringMap[str]);
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("vertical"))) {
-                            static QMap<QString, Format::VerticalAlignment> alignStringMap;
-                            if (alignStringMap.isEmpty()) {
-                                alignStringMap.insert(QStringLiteral("top"), Format::AlignTop);
-                                alignStringMap.insert(QStringLiteral("center"), Format::AlignVCenter);
-                                alignStringMap.insert(QStringLiteral("justify"), Format::AlignVJustify);
-                                alignStringMap.insert(QStringLiteral("distributed"), Format::AlignVDistributed);
-                            }
+                            static const QMap<QString, Format::VerticalAlignment> alignStringMap = {
+                                {QStringLiteral("top"), Format::AlignTop},
+                                {QStringLiteral("center"), Format::AlignVCenter},
+                                {QStringLiteral("justify"), Format::AlignVJustify},
+                                {QStringLiteral("distributed"), Format::AlignVDistributed}
+                            };
                             QString str = alignAttrs.value(QLatin1String("vertical")).toString();
                             if (alignStringMap.contains(str))
                                 format.setVerticalAlignment(alignStringMap[str]);


### PR DESCRIPTION
# Problem
QXlsx not support multithread task before, e.g.:
1. Create multiple threads
2. In each thread, create a individual `QXlsx::Document` object
3. Write data to `QXlsx::Document` object
4. Save `QXlsx::Document` object to .xlsx file

# Causation
The program crashed at step 4, because QXlsx use some static variables internally, which are not thread safe:
1. Some are constant dictionaries like `static QMap<DataValidation::ValidationType, QString> typeMap`, which is safe to read concurrently, but their initialization are not thread-safe.
2. Some are caches like `static QMap<int, QString> col_cache`, which should be independent from each `QXlsx::Document` object but infact is not.

# Solution
I've done some tiny refactor to solve this problem:
1. For this case, initialize them with C++11 initializer-list, which is guaranteed to be thread-safe in static variable initialization.
2. For this case, add `thread_local` keyword to the  definition, so the variable will have an individual instance in each thread, it behaves same as single-threaded version in each thread.

# Validation
I have a situation which converts hex file into xlsx documemt.

So I copied a 110MB file for 8 times, converts them to xlsx documents in parallel.

Then I unzipped each .xlsx file, compare theire contents with diff tool, which result in same.