### PR TITLE
Strict fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,23 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(QXlsx)
+project(QXlsx VERSION 1.0.0 LANGUAGES CXX)
 
-#------------------------------------------------------------------------------
-# Qt
-#------------------------------------------------------------------------------
-find_package(Qt5 REQUIRED QUIET COMPONENTS Core Gui)
+find_package(Qt5 5.6.0 REQUIRED COMPONENTS Core Gui)
 find_package(Qt5Gui CONFIG REQUIRED Private)
 set(CMAKE_AUTOMOC ON)
+
+add_definitions(
+    -DQT_NO_KEYWORDS
+    -DQT_NO_CAST_TO_ASCII
+    -DQT_NO_CAST_FROM_ASCII
+    -DQT_STRICT_ITERATORS
+    -DQT_NO_URL_CAST_FROM_STRING
+    -DQT_NO_CAST_FROM_BYTEARRAY
+    -DQT_USE_QSTRINGBUILDER
+    -DQT_NO_SIGNALS_SLOTS_KEYWORDS
+    -DQT_USE_FAST_OPERATOR_PLUS
+    -DQT_DISABLE_DEPRECATED_BEFORE=0x050c00
+)
 
 #------------------------------------------------------------------------------
 # Library

--- a/QXlsx/header/xlsxchart_p.h
+++ b/QXlsx/header/xlsxchart_p.h
@@ -22,10 +22,10 @@ class XlsxSeries
 {
 public:
     //At present, we care about number cell ranges only!
-    QString numberDataSource_numRef = ""; // yval, val
-    QString axDataSource_numRef = ""; // xval, cat
-    QString headerH_numRef = "";
-    QString headerV_numRef = "";
+    QString numberDataSource_numRef; // yval, val
+    QString axDataSource_numRef; // xval, cat
+    QString headerH_numRef;
+    QString headerV_numRef;
     bool    swapHeader = false;
 };
 
@@ -41,7 +41,7 @@ public:
               XlsxAxis::AxisPos p,
               int id,
               int crossId,
-              QString axisTitle = QString("") )
+              QString axisTitle = QString())
     {
         type = t;
         axisPos = p;

--- a/QXlsx/header/xlsxdocpropsapp_p.h
+++ b/QXlsx/header/xlsxdocpropsapp_p.h
@@ -39,7 +39,6 @@
 #include "xlsxglobal.h"
 #include "xlsxabstractooxmlfile.h"
 #include <QList>
-#include <QPair>
 #include <QStringList>
 #include <QMap>
 
@@ -64,7 +63,7 @@ public:
 
 private:
     QStringList m_titlesOfPartsList;
-    QList<QPair<QString, int> > m_headingPairsList;
+    QList<std::pair<QString, int> > m_headingPairsList;
     QMap<QString, QString> m_properties;
 };
 

--- a/QXlsx/source/xlsxcell.cpp
+++ b/QXlsx/source/xlsxcell.cpp
@@ -25,9 +25,13 @@ CellPrivate::CellPrivate(Cell *p) :
 }
 
 CellPrivate::CellPrivate(const CellPrivate * const cp)
-	: value(cp->value), formula(cp->formula), cellType(cp->cellType)
-	, format(cp->format), richString(cp->richString), parent(cp->parent),
-	styleNumber(cp->styleNumber)
+    : parent(cp->parent)
+    , cellType(cp->cellType)
+    , value(cp->value)
+    , formula(cp->formula)
+    , format(cp->format)
+    , richString(cp->richString)
+    , styleNumber(cp->styleNumber)
 {
 
 }
@@ -248,7 +252,7 @@ bool Cell::isDateTime() const
 
 	Cell::CellType cellType = d->cellType;
     double dValue = d->value.toDouble(); // number
-	QString strValue = d->value.toString().toUtf8(); 
+//	QString strValue = d->value.toString().toUtf8();
 	bool isValidFormat = d->format.isValid();
     bool isDateTimeFormat = d->format.isDateTimeFormat(); // datetime format
 

--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -111,7 +111,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerH_numRef = "";
+                series->headerH_numRef = QString();
             }
             if( headerV )
             {
@@ -120,7 +120,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerV_numRef = "";
+                series->headerV_numRef = QString();
             }
             series->swapHeader = swapHeaders;
 
@@ -165,7 +165,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerH_numRef = "";
+                series->headerH_numRef = QString();
             }
 
             if( headerV )
@@ -175,7 +175,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerV_numRef = "";
+                series->headerV_numRef = QString();
             }
             series->swapHeader = swapHeaders;
 
@@ -1056,26 +1056,26 @@ void ChartPrivate::saveXmlChartLegend(QXmlStreamWriter &writer) const
             {
                 //case Chart::ChartAxisPos::Right:
                 case Chart::Right :
-                    pos = "r";
+                    pos = QStringLiteral("r");
                     break;
 
                 // case Chart::ChartAxisPos::Left:
                 case Chart::Left :
-                    pos = "l";
+                    pos = QStringLiteral("l");
                     break;
 
                 // case Chart::ChartAxisPos::Top:
                 case Chart::Top :
-                    pos = "t";
+                    pos = QStringLiteral("t");
                     break;
 
                 // case Chart::ChartAxisPos::Bottom:
                 case Chart::Bottom :
-                    pos = "b";
+                    pos = QStringLiteral("b");
                     break;
 
                 default:
-                    pos = "r";
+                    pos = QStringLiteral("r");
                     break;
             }
 
@@ -1143,7 +1143,7 @@ void ChartPrivate::saveXmlBarChart(QXmlStreamWriter &writer) const
 
 
     // Note: Bar3D have 2~3 axes
-    int axisListSize = axisList.size();
+    // int axisListSize = axisList.size();
     // [dev62]
     // Q_ASSERT( axisListSize == 2 ||
     //          ( axisListSize == 3 && chartType == Chart::CT_Bar3DChart ) );
@@ -1466,7 +1466,7 @@ bool ChartPrivate::loadXmlAxisValAx(QXmlStreamReader &reader)
 bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* axis)
 {
     Q_ASSERT( NULL != axis );
-    Q_ASSERT( reader.name().endsWith("Ax") );
+    Q_ASSERT( reader.name().endsWith(QLatin1String("Ax")) );
     QString name = reader.name().toString(); //
 
     while ( !reader.atEnd() )
@@ -1479,7 +1479,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             if ( reader.name() == QLatin1String("axId") ) // mandatory element
             {
                 // dev57
-                uint axId = reader.attributes().value("val").toString().toUInt(); // for Qt5.1
+                uint axId = reader.attributes().value(QStringLiteral("val")).toString().toUInt(); // for Qt5.1
                 axis->axisId = axId;
             }
             else if ( reader.name() == QLatin1String("scaling") )
@@ -1498,10 +1498,10 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
 
                 QString axPosVal = reader.attributes().value(QLatin1String("val")).toString();
 
-                if ( axPosVal == "l" ) { axis->axisPos = XlsxAxis::Left; }
-                else if ( axPosVal == "r" ) { axis->axisPos = XlsxAxis::Right; }
-                else if ( axPosVal == "t" ) { axis->axisPos = XlsxAxis::Top; }
-                else if ( axPosVal == "b" ) { axis->axisPos = XlsxAxis::Bottom; }
+                if ( axPosVal == QLatin1String("l") ) { axis->axisPos = XlsxAxis::Left; }
+                else if ( axPosVal == QLatin1String("r") ) { axis->axisPos = XlsxAxis::Right; }
+                else if ( axPosVal == QLatin1String("t") ) { axis->axisPos = XlsxAxis::Top; }
+                else if ( axPosVal == QLatin1String("b") ) { axis->axisPos = XlsxAxis::Bottom; }
             }
             else if ( reader.name() == QLatin1String("majorGridlines") )
             {
@@ -1592,7 +1592,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Scaling(QXmlStreamReader &reader, Xlsx
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "scaling" )
+                  reader.name() == QLatin1String("scaling") )
         {
             break;
         }
@@ -1661,7 +1661,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title(QXmlStreamReader &reader, XlsxAx
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "title" )
+                  reader.name() == QLatin1String("title") )
         {
             break;
         }
@@ -1682,7 +1682,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Overlay(QXmlStreamReader &reader
         {
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "overlay" )
+                  reader.name() == QLatin1String("overlay") )
         {
             break;
         }
@@ -1709,7 +1709,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx(QXmlStreamReader &reader, Xls
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "tx" )
+                  reader.name() == QLatin1String("tx") )
         {
             break;
         }
@@ -1736,7 +1736,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich(QXmlStreamReader &reader
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "rich" )
+                  reader.name() == QLatin1String("rich") )
         {
             break;
         }
@@ -1768,7 +1768,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P(QXmlStreamReader &read
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "p" )
+                  reader.name() == QLatin1String("p") )
         {
             break;
         }
@@ -1796,7 +1796,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_pPr(QXmlStreamReader &
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "pPr" )
+                  reader.name() == QLatin1String("pPr") )
         {
             break;
         }
@@ -1825,7 +1825,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_R(QXmlStreamReader &re
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "r" )
+                  reader.name() == QLatin1String("r") )
         {
             break;
         }
@@ -1951,7 +1951,7 @@ void ChartPrivate::saveXmlAxisCatAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:catAx");
+    writer.writeStartElement(QStringLiteral("c:catAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -1985,7 +1985,7 @@ void ChartPrivate::saveXmlAxisDateAx(QXmlStreamWriter &writer, XlsxAxis* axis) c
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:dateAx");
+    writer.writeStartElement(QStringLiteral("c:dateAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2015,7 +2015,7 @@ void ChartPrivate::saveXmlAxisSerAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:serAx");
+    writer.writeStartElement(QStringLiteral("c:serAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2042,7 +2042,7 @@ void ChartPrivate::saveXmlAxisValAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:valAx");
+    writer.writeStartElement(QStringLiteral("c:valAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2100,11 +2100,11 @@ void ChartPrivate::saveXmlAxisEG_AxShared(QXmlStreamWriter &writer, XlsxAxis* ax
 
     if( majorGridlinesEnabled )
     {
-        writer.writeEmptyElement("c:majorGridlines");
+        writer.writeEmptyElement(QStringLiteral("c:majorGridlines"));
     }
     if( minorGridlinesEnabled )
     {
-        writer.writeEmptyElement("c:minorGridlines");
+        writer.writeEmptyElement(QStringLiteral("c:minorGridlines"));
     }
 
     saveXmlAxisEG_AxShared_Title(writer, axis); // "c:title" CT_Title
@@ -2159,28 +2159,28 @@ void ChartPrivate::saveXmlAxisEG_AxShared_Title(QXmlStreamWriter &writer, XlsxAx
     </xsd:complexType>
     */
 
-    writer.writeStartElement("c:title");
+    writer.writeStartElement(QStringLiteral("c:title"));
 
     // CT_Tx {{
-     writer.writeStartElement("c:tx");
+     writer.writeStartElement(QStringLiteral("c:tx"));
 
-      writer.writeStartElement("c:rich"); // CT_TextBody
+      writer.writeStartElement(QStringLiteral("c:rich")); // CT_TextBody
 
        writer.writeEmptyElement(QStringLiteral("a:bodyPr")); // CT_TextBodyProperties
 
        writer.writeEmptyElement(QStringLiteral("a:lstStyle")); // CT_TextListStyle
 
-       writer.writeStartElement("a:p");
+       writer.writeStartElement(QStringLiteral("a:p"));
 
-        writer.writeStartElement("a:pPr");
+        writer.writeStartElement(QStringLiteral("a:pPr"));
             writer.writeAttribute(QStringLiteral("lvl"), QString::number(0));
 
-            writer.writeStartElement("a:defRPr");
+            writer.writeStartElement(QStringLiteral("a:defRPr"));
             writer.writeAttribute(QStringLiteral("b"), QString::number(0));
             writer.writeEndElement(); // a:defRPr
         writer.writeEndElement(); // a:pPr
 
-        writer.writeStartElement("a:r");
+        writer.writeStartElement(QStringLiteral("a:r"));
         QString strAxisName = GetAxisName(axis);
         writer.writeTextElement( QStringLiteral("a:t"), strAxisName );
         writer.writeEndElement(); // a:r
@@ -2192,7 +2192,7 @@ void ChartPrivate::saveXmlAxisEG_AxShared_Title(QXmlStreamWriter &writer, XlsxAx
      writer.writeEndElement(); // c:tx
      // CT_Tx }}
 
-     writer.writeStartElement("c:overlay");
+     writer.writeStartElement(QStringLiteral("c:overlay"));
         writer.writeAttribute(QStringLiteral("val"), QString::number(0)); // CT_Boolean
      writer.writeEndElement(); // c:overlay
 
@@ -2248,13 +2248,13 @@ QString ChartPrivate::readSubTree(QXmlStreamReader &reader)
         {
             prefix = reader.prefix().toString();
 
-            treeString += QString("<" + reader.qualifiedName().toString() );
+            treeString += QLatin1String("<") + reader.qualifiedName().toString();
 
-            foreach(const QXmlStreamAttribute &attr, reader.attributes())
-            {
-                treeString += QString( " " + attr.name().toString() + "=\"" + attr.value().toString() + "\"");
+            const QXmlStreamAttributes attributes = reader.attributes();
+            for (const QXmlStreamAttribute &attr : attributes) {
+                treeString += QLatin1String(" ") + attr.name().toString() + QLatin1String("=\"") + attr.value().toString() + QLatin1String("\"");
             }
-            treeString += ">";
+            treeString += QStringLiteral(">");
         }
         else if (reader.tokenType() == QXmlStreamReader::EndElement )
         {
@@ -2262,7 +2262,7 @@ QString ChartPrivate::readSubTree(QXmlStreamReader &reader)
             {
                 break;
             }
-            treeString += QString("</" + reader.qualifiedName().toString() + ">");
+            treeString += QLatin1String("</") + reader.qualifiedName().toString() + QLatin1String(">");
         }
     }
 
@@ -2288,25 +2288,25 @@ bool ChartPrivate::loadXmlChartLegend(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("legendPos")) // c:legendPos
             {
                 QString pos = reader.attributes().value(QLatin1String("val")).toString();
-                if( pos.compare("r",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("r"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Right;
                     legendPos = Chart::Right;
                 }
                 else
-                if( pos.compare("l",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("l"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Left;
                     legendPos = Chart::Left;
                 }
                 else
-                if( pos.compare("t",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("t"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Top;
                     legendPos = Chart::Top;
                 }
                 else
-                if( pos.compare("b",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("b"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Bottom;
                     legendPos = Chart::Bottom;
@@ -2321,7 +2321,7 @@ bool ChartPrivate::loadXmlChartLegend(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("overlay")) // c:legendPos
             {
                 QString pos = reader.attributes().value(QLatin1String("val")).toString();
-                if( pos.compare("1",Qt::CaseInsensitive) == 0 )
+                if( pos.compare(QLatin1String("1"), Qt::CaseInsensitive) == 0 )
                 {
                     legendOverlay = true;
                 }

--- a/QXlsx/source/xlsxchartsheet.cpp
+++ b/QXlsx/source/xlsxchartsheet.cpp
@@ -106,10 +106,10 @@ void Chartsheet::saveToXmlFile(QIODevice *device) const
     writer.writeEndElement(); //sheetViews
 
     int idx = d->workbook->drawings().indexOf(d->drawing.data());
-    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
+    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("drawing"));
-    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
 
     writer.writeEndElement();//chartsheet
     writer.writeEndDocument();

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -204,19 +204,19 @@ bool ConditionalFormatting::addHighlightCellsRule(HighlightRuleType type, const 
         if (type == Highlight_ContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("containsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("containsText");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
         } else if (type == Highlight_NotContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("notContainsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("notContains");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
         } else if (type == Highlight_BeginsWith) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("beginsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("beginsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         } else {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("endsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("endsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         }
         cfRule->attrs[XlsxCfRuleData::A_text] = formula1;
         skipFormula = true;
@@ -631,9 +631,11 @@ bool ConditionalFormatting::loadFromXml(QXmlStreamReader &reader, Styles *styles
     d->ranges.clear();
     d->cfRules.clear();
     QXmlStreamAttributes attrs = reader.attributes();
-    QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    foreach (QString range, sqref.split(QLatin1Char(' ')))
+    const QString sqref = attrs.value(QLatin1String("sqref")).toString();
+    const auto sqrefParts = sqref.split(QLatin1Char(' '));
+    for (const QString &range : sqrefParts) {
         this->addRange(range);
+    }
 
     while (!reader.atEnd()) {
         reader.readNextStartElement();
@@ -658,8 +660,10 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("conditionalFormatting"));
     QStringList sqref;
-    foreach (CellRange range, ranges())
+    const auto rangeList = ranges();
+    for (const CellRange &range : rangeList) {
         sqref.append(range.toString());
+    }
     writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
     for (int i=0; i<d->cfRules.size(); ++i) {

--- a/QXlsx/source/xlsxcontenttypes.cpp
+++ b/QXlsx/source/xlsxcontenttypes.cpp
@@ -38,7 +38,7 @@ ContentTypes::ContentTypes(CreateFlag flag)
     m_package_prefix = QStringLiteral("application/vnd.openxmlformats-package.");
     m_document_prefix = QStringLiteral("application/vnd.openxmlformats-officedocument.");
 
-    m_defaults.insert(QStringLiteral("rels"), m_package_prefix + QStringLiteral("relationships+xml"));
+    m_defaults.insert(QStringLiteral("rels"), m_package_prefix + QLatin1String("relationships+xml"));
     m_defaults.insert(QStringLiteral("xml"), QStringLiteral("application/xml"));
 }
 
@@ -54,77 +54,77 @@ void ContentTypes::addOverride(const QString &key, const QString &value)
 
 void ContentTypes::addDocPropApp()
 {
-    addOverride(QStringLiteral("/docProps/app.xml"), m_document_prefix + QStringLiteral("extended-properties+xml"));
+    addOverride(QStringLiteral("/docProps/app.xml"), m_document_prefix + QLatin1String("extended-properties+xml"));
 }
 
 void ContentTypes::addDocPropCore()
 {
-    addOverride(QStringLiteral("/docProps/core.xml"), m_package_prefix + QStringLiteral("core-properties+xml"));
+    addOverride(QStringLiteral("/docProps/core.xml"), m_package_prefix + QLatin1String("core-properties+xml"));
 }
 
 void ContentTypes::addStyles()
 {
-    addOverride(QStringLiteral("/xl/styles.xml"), m_document_prefix + QStringLiteral("spreadsheetml.styles+xml"));
+    addOverride(QStringLiteral("/xl/styles.xml"), m_document_prefix + QLatin1String("spreadsheetml.styles+xml"));
 }
 
 void ContentTypes::addTheme()
 {
-    addOverride(QStringLiteral("/xl/theme/theme1.xml"), m_document_prefix + QStringLiteral("theme+xml"));
+    addOverride(QStringLiteral("/xl/theme/theme1.xml"), m_document_prefix + QLatin1String("theme+xml"));
 }
 
 void ContentTypes::addWorkbook()
 {
-    addOverride(QStringLiteral("/xl/workbook.xml"), m_document_prefix + QStringLiteral("spreadsheetml.sheet.main+xml"));
+    addOverride(QStringLiteral("/xl/workbook.xml"), m_document_prefix + QLatin1String("spreadsheetml.sheet.main+xml"));
 }
 
 void ContentTypes::addWorksheetName(const QString &name)
 {
-    addOverride(QString("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.worksheet+xml"));
+    addOverride(QStringLiteral("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.worksheet+xml"));
 }
 
 void ContentTypes::addChartsheetName(const QString &name)
 {
-    addOverride(QString("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.chartsheet+xml"));
+    addOverride(QStringLiteral("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.chartsheet+xml"));
 }
 
 void ContentTypes::addDrawingName(const QString &name)
 {
-    addOverride(QString("/xl/drawings/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawing+xml"));
+    addOverride(QStringLiteral("/xl/drawings/%1.xml").arg(name), m_document_prefix + QLatin1String("drawing+xml"));
 }
 
 void ContentTypes::addChartName(const QString &name)
 {
-    addOverride(QString("/xl/charts/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawingml.chart+xml"));
+    addOverride(QStringLiteral("/xl/charts/%1.xml").arg(name), m_document_prefix + QLatin1String("drawingml.chart+xml"));
 }
 
 void ContentTypes::addCommentName(const QString &name)
 {
-    addOverride(QString("/xl/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.comments+xml"));
+    addOverride(QStringLiteral("/xl/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.comments+xml"));
 }
 
 void ContentTypes::addTableName(const QString &name)
 {
-    addOverride(QString("/xl/tables/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.table+xml"));
+    addOverride(QStringLiteral("/xl/tables/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.table+xml"));
 }
 
 void ContentTypes::addExternalLinkName(const QString &name)
 {
-    addOverride(QString("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.externalLink+xml"));
+    addOverride(QStringLiteral("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.externalLink+xml"));
 }
 
 void ContentTypes::addSharedString()
 {
-    addOverride(QStringLiteral("/xl/sharedStrings.xml"), m_document_prefix + QStringLiteral("spreadsheetml.sharedStrings+xml"));
+    addOverride(QStringLiteral("/xl/sharedStrings.xml"), m_document_prefix + QLatin1String("spreadsheetml.sharedStrings+xml"));
 }
 
 void ContentTypes::addVmlName()
 {
-    addOverride(QStringLiteral("vml"), m_document_prefix + QStringLiteral("vmlDrawing"));
+    addOverride(QStringLiteral("vml"), m_document_prefix + QLatin1String("vmlDrawing"));
 }
 
 void ContentTypes::addCalcChain()
 {
-    addOverride(QStringLiteral("/xl/calcChain.xml"), m_document_prefix + QStringLiteral("spreadsheetml.calcChain+xml"));
+    addOverride(QStringLiteral("/xl/calcChain.xml"), m_document_prefix + QLatin1String("spreadsheetml.calcChain+xml"));
 }
 
 void ContentTypes::addVbaProject()

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -443,7 +443,8 @@ bool DataValidation::saveToXml(QXmlStreamWriter &writer) const
         writer.writeAttribute(QStringLiteral("prompt"), promptMessage());
 
     QStringList sqref;
-    foreach (CellRange range, ranges())
+    const auto rangeList = ranges();
+    for (const CellRange &range : rangeList)
         sqref.append(range.toString());
     writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
@@ -496,7 +497,8 @@ DataValidation DataValidation::loadFromXml(QXmlStreamReader &reader)
     QXmlStreamAttributes attrs = reader.attributes();
 
     QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    foreach (QString range, sqref.split(QLatin1Char(' ')))
+    const auto sqrefParts = sqref.split(QLatin1Char(' '));
+    for (const QString &range : sqrefParts)
         validation.addRange(range);
 
     if (attrs.hasAttribute(QLatin1String("type"))) {

--- a/QXlsx/source/xlsxdocpropsapp.cpp
+++ b/QXlsx/source/xlsxdocpropsapp.cpp
@@ -46,7 +46,7 @@ void DocPropsApp::addPartTitle(const QString &title)
 
 void DocPropsApp::addHeadingPair(const QString &name, int value)
 {
-    m_headingPairsList.append(qMakePair(name, value));
+    m_headingPairsList.append({ name, value });
 }
 
 bool DocPropsApp::setProperty(const QString &name, const QString &value)
@@ -96,8 +96,8 @@ void DocPropsApp::saveToXmlFile(QIODevice *device) const
     writer.writeStartElement(vt, QStringLiteral("vector"));
     writer.writeAttribute(QStringLiteral("size"), QString::number(m_headingPairsList.size()*2));
     writer.writeAttribute(QStringLiteral("baseType"), QStringLiteral("variant"));
-    typedef QPair<QString,int> PairType; //Make foreach happy
-    foreach (PairType pair, m_headingPairsList) {
+
+    for (const auto &pair : m_headingPairsList) {
         writer.writeStartElement(vt, QStringLiteral("variant"));
         writer.writeTextElement(vt, QStringLiteral("lpstr"), pair.first);
         writer.writeEndElement(); //vt:variant
@@ -112,7 +112,7 @@ void DocPropsApp::saveToXmlFile(QIODevice *device) const
     writer.writeStartElement(vt, QStringLiteral("vector"));
     writer.writeAttribute(QStringLiteral("size"), QString::number(m_titlesOfPartsList.size()));
     writer.writeAttribute(QStringLiteral("baseType"), QStringLiteral("lpstr"));
-    foreach (QString title, m_titlesOfPartsList)
+    for (const QString &title : m_titlesOfPartsList)
         writer.writeTextElement(vt, QStringLiteral("lpstr"), title);
     writer.writeEndElement();//vt:vector
     writer.writeEndElement();//TitlesOfParts

--- a/QXlsx/source/xlsxdocument.cpp
+++ b/QXlsx/source/xlsxdocument.cpp
@@ -195,7 +195,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
 		DocPropsCore props(DocPropsCore::F_LoadFromExists);
 		props.loadFromXmlData(zipReader.fileData(docPropsCore_Name));
-		foreach (QString name, props.propertyNames())
+        for (const QString &name : props.propertyNames())
 			q->setDocumentProperty(name, props.property(name));
 	}
 
@@ -208,7 +208,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
 		DocPropsApp props(DocPropsApp::F_LoadFromExists);
 		props.loadFromXmlData(zipReader.fileData(docPropsApp_Name));
-		foreach (QString name, props.propertyNames())
+        for (const QString &name : props.propertyNames())
 			q->setDocumentProperty(name, props.property(name));
 	}
 
@@ -234,7 +234,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
         // dev34
         QString path;
-        if ( xlworkbook_Dir == "." ) // root
+        if ( xlworkbook_Dir == QLatin1String(".") ) // root
         {
             path = name;
         }
@@ -337,42 +337,42 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
     for (int i = 0 ; i < worksheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = worksheets[i];
-		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
+        contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QString("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	//save chartsheet xml files
 	QList<QSharedPointer<AbstractSheet> > chartsheets = workbook->getSheetsByTypes(AbstractSheet::ST_ChartSheet);
 	if (!chartsheets.isEmpty())
-		docPropsApp.addHeadingPair(QStringLiteral("Chartsheets"), chartsheets.size());
+        docPropsApp.addHeadingPair(QStringLiteral("Chartsheets"), chartsheets.size());
     for (int i=0; i<chartsheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = chartsheets[i];
-		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
+        contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QString("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save external links xml files
     for (int i=0; i<workbook->d_func()->externalLinks.count(); ++i)
     {
 		SimpleOOXmlFile *link = workbook->d_func()->externalLinks[i].data();
-		contentTypes->addExternalLinkName(QString("externalLink%1").arg(i+1));
+        contentTypes->addExternalLinkName(QStringLiteral("externalLink%1").arg(i+1));
 
-		zipWriter.addFile(QString("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
 		Relationships *rel = link->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save workbook xml file
@@ -383,16 +383,16 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save drawing xml files
     for (int i=0; i<workbook->drawings().size(); ++i)
     {
-		contentTypes->addDrawingName(QString("drawing%1").arg(i+1));
+        contentTypes->addDrawingName(QStringLiteral("drawing%1").arg(i+1));
 
 		Drawing *drawing = workbook->drawings()[i];
-		zipWriter.addFile(QString("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
 		if (!drawing->relationships()->isEmpty())
-			zipWriter.addFile(QString("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
 	}
 
 	// save docProps app/core xml file
-	foreach (QString name, q->documentPropertyNames()) {
+    for (const QString &name : q->documentPropertyNames()) {
 		docPropsApp.setProperty(name, q->documentProperty(name));
 		docPropsCore.setProperty(name, q->documentProperty(name));
 	}
@@ -422,9 +422,9 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save chart xml files
     for (int i=0; i<workbook->chartFiles().size(); ++i)
     {
-		contentTypes->addChartName(QString("chart%1").arg(i+1));
+        contentTypes->addChartName(QStringLiteral("chart%1").arg(i+1));
 		QSharedPointer<Chart> cf = workbook->chartFiles()[i];
-		zipWriter.addFile(QString("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
 	}
 
 	// save image files
@@ -434,7 +434,7 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 		if (!mf->mimeType().isEmpty())
 			contentTypes->addDefault(mf->suffix(), mf->mimeType());
 
-		zipWriter.addFile(QString("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
+        zipWriter.addFile(QStringLiteral("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
 	}
 
 	// save root .rels xml file
@@ -471,11 +471,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 
 	// copy all files from "to" zip except those related to style
 	for (int i = 0; i < toFilePaths.size(); i++) {
-		if (toFilePaths[i].contains("xl/styles")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/styles"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// style file exist in 'from' as well
 				// modify style file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy default theme style from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "dxfs");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -484,11 +484,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 			}
 		}
 
-		if (toFilePaths[i].contains("xl/workbook")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/workbook"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// workbook file exist in 'from' as well
 				// modify workbook file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy default theme style from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "workbookPr");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -496,11 +496,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 			}
 		}
 
-		if (toFilePaths[i].contains("xl/worksheets/sheet")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/worksheets/sheet"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// sheet file exist in 'from' as well
 				// modify sheet file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy "conditionalFormatting" from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "conditionalFormatting");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -1254,14 +1254,14 @@ bool Document::changeimage(int filenoinmidea, QString newfile)
 	
 	const QString suffix = newfile.mid(newfile.lastIndexOf(QLatin1Char('.'))+1);
 	QString mimetypemy;
-	if(QString::compare("jpg", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/jpeg";
-	if(QString::compare("bmp", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/bmp";
-	if(QString::compare("gif", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/gif";
-	if(QString::compare("png", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/png";
+    if(QString::compare(QLatin1String("jpg"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/jpeg");
+    if(QString::compare(QLatin1String("bmp"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/bmp");
+    if(QString::compare(QLatin1String("gif"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/gif");
+    if(QString::compare(QLatin1String("png"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/png");
 	
 	QByteArray ba;
 	QBuffer buffer(&ba);
@@ -1332,7 +1332,7 @@ bool Document::autosizeColumnWidth(const CellRange &range)
 
     QMap<int, int> colWidth = getMaximalColumnWidth(range.firstRow(), range.lastRow());
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( (key >= range.firstColumn()) && (key <= range.lastColumn()) )
         {
@@ -1354,7 +1354,7 @@ bool Document::autosizeColumnWidth(int column)
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( key == column)
         {
@@ -1372,11 +1372,13 @@ bool Document::autosizeColumnWidth(int column)
  */
 bool Document::autosizeColumnWidth(int colFirst, int colLast)
 {
+    Q_UNUSED(colFirst)
+    Q_UNUSED(colLast)
     bool erg = false;
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( (key >= colFirst) && (key <= colLast) )
         {
@@ -1398,7 +1400,7 @@ bool Document::autosizeColumnWidth(void)
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         erg |= setColumnWidth(key, colWidth.value(key));
     }

--- a/QXlsx/source/xlsxdrawing.cpp
+++ b/QXlsx/source/xlsxdrawing.cpp
@@ -55,7 +55,7 @@ void Drawing::saveToXmlFile(QIODevice *device) const
     writer.writeAttribute(QStringLiteral("xmlns:xdr"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"));
     writer.writeAttribute(QStringLiteral("xmlns:a"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/main"));
 
-    foreach (DrawingAnchor *anchor, anchors)
+    for (DrawingAnchor *anchor : anchors)
         anchor->saveToXml(writer);
 
     writer.writeEndElement();//xdr:wsDr

--- a/QXlsx/source/xlsxdrawinganchor.cpp
+++ b/QXlsx/source/xlsxdrawinganchor.cpp
@@ -741,7 +741,7 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvGraphicFramePr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id));
-    writer.writeAttribute(QStringLiteral("name"), QString("Chart %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QStringLiteral("Chart %1").arg(m_id));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvGraphicFramePr"));
     writer.writeEndElement();//xdr:nvGraphicFramePr
 
@@ -753,12 +753,12 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeAttribute(QStringLiteral("uri"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
 
     int idx = m_drawing->workbook->chartFiles().indexOf(m_chartFile);
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QString("../charts/chart%1.xml").arg(idx+1));
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QStringLiteral("../charts/chart%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("c:chart"));
     writer.writeAttribute(QStringLiteral("xmlns:c"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
 
     writer.writeEndElement(); //a:graphicData
     writer.writeEndElement(); //a:graphic
@@ -779,7 +779,7 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvPicPr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id+1)); // liufeijin
-    writer.writeAttribute(QStringLiteral("name"), QString("Picture %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QStringLiteral("Picture %1").arg(m_id));
 
     writer.writeStartElement(QStringLiteral("xdr:cNvPicPr"));
     writer.writeEmptyElement(QStringLiteral("a:picLocks"));
@@ -788,14 +788,14 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
 
     writer.writeEndElement(); //xdr:nvPicPr
 
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2")
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2")
                                                      .arg(m_pictureFile->index()+1)
                                                      .arg(m_pictureFile->suffix()));
 
     writer.writeStartElement(QStringLiteral("xdr:blipFill"));
     writer.writeEmptyElement(QStringLiteral("a:blip"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:embed"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
     writer.writeStartElement(QStringLiteral("a:stretch"));
     writer.writeEmptyElement(QStringLiteral("a:fillRect"));
     writer.writeEndElement(); //a:stretch
@@ -852,13 +852,13 @@ void DrawingAnchor::saveXmlObjectShape(QXmlStreamWriter &writer) const
         writer.writeEndElement(); //a:prstGeom
 
     if(!m_pictureFile.isNull()){
-        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
+        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
         writer.writeStartElement(QStringLiteral("a:blipFill"));
         writer.writeAttribute(QStringLiteral("dpi"), QString::number(dpiTA));
         writer.writeAttribute(QStringLiteral("rotWithShape"),QString::number(rotWithShapeTA));
 
          writer.writeStartElement(QStringLiteral("a:blip"));
-           writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
+           writer.writeAttribute(QStringLiteral("r:embed"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
            writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
            if(!sp_blip_cstate.isNull()){
              writer.writeAttribute(QStringLiteral("cstate"), sp_blip_cstate);

--- a/QXlsx/source/xlsxrelationships.cpp
+++ b/QXlsx/source/xlsxrelationships.cpp
@@ -82,7 +82,7 @@ void Relationships::addWorksheetRelationship(const QString &relativeType, const 
 QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 {
     QList<XlsxRelationship> res;
-    foreach (XlsxRelationship ship, m_relationships) {
+    for (const XlsxRelationship &ship : m_relationships) {
         if (ship.type == type)
             res.append(ship);
     }
@@ -92,7 +92,7 @@ QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 void Relationships::addRelationship(const QString &type, const QString &target, const QString &targetMode)
 {
     XlsxRelationship relation;
-    relation.id = QString("rId%1").arg(m_relationships.size()+1);
+    relation.id = QStringLiteral("rId%1").arg(m_relationships.size()+1);
     relation.type = type;
     relation.target = target;
     relation.targetMode = targetMode;
@@ -107,7 +107,7 @@ void Relationships::saveToXmlFile(QIODevice *device) const
     writer.writeStartDocument(QStringLiteral("1.0"), true);
     writer.writeStartElement(QStringLiteral("Relationships"));
     writer.writeAttribute(QStringLiteral("xmlns"), QStringLiteral("http://schemas.openxmlformats.org/package/2006/relationships"));
-    foreach (XlsxRelationship relation, m_relationships) {
+    for (const XlsxRelationship &relation : m_relationships) {
         writer.writeStartElement(QStringLiteral("Relationship"));
         writer.writeAttribute(QStringLiteral("Id"), relation.id);
         writer.writeAttribute(QStringLiteral("Type"), relation.type);
@@ -164,7 +164,7 @@ bool Relationships::loadFromXmlData(const QByteArray &data)
 
 XlsxRelationship Relationships::getRelationshipById(const QString &id) const
 {
-    foreach (XlsxRelationship ship, m_relationships) {
+    for (const XlsxRelationship &ship : m_relationships) {
         if (ship.id == id)
             return ship;
     }

--- a/QXlsx/source/xlsxrichstring.cpp
+++ b/QXlsx/source/xlsxrichstring.cpp
@@ -130,7 +130,7 @@ bool RichString::isNull() const
  */
 bool RichString::isEmtpy() const
 {
-    foreach (const QString str, d->fragmentTexts) {
+    for (const QString str : d->fragmentTexts) {
         if (!str.isEmpty())
             return false;
     }

--- a/QXlsx/source/xlsxsharedstrings.cpp
+++ b/QXlsx/source/xlsxsharedstrings.cpp
@@ -203,7 +203,7 @@ void SharedStrings::saveToXmlFile(QIODevice *device) const
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_stringCount));
     writer.writeAttribute(QStringLiteral("uniqueCount"), QString::number(m_stringList.size()));
 
-    foreach (RichString string, m_stringList) {
+    for (const RichString &string : m_stringList) {
         writer.writeStartElement(QStringLiteral("si"));
         if (string.isRichString()) {
             //Rich text string

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -597,7 +597,7 @@ void Styles::writeCellXfs(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("cellXfs"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_xf_formatsList.size()));
-    foreach (const Format &format, m_xf_formatsList) {
+    for (const Format &format : m_xf_formatsList) {
         int xf_id = 0;
         writer.writeStartElement(QStringLiteral("xf"));
         writer.writeAttribute(QStringLiteral("numFmtId"), QString::number(format.numberFormatIndex()));
@@ -683,7 +683,7 @@ void Styles::writeDxfs(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("dxfs"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_dxf_formatsList.size()));
-    foreach (const Format &format, m_dxf_formatsList)
+    for (const Format &format : m_dxf_formatsList)
         writeDxf(writer, format);
     writer.writeEndElement(); //dxfs
 }
@@ -718,7 +718,7 @@ void Styles::writeColors(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("colors"));
 
     writer.writeStartElement(QStringLiteral("indexedColors"));
-    foreach(QColor color, m_indexedColors) {
+    for (const QColor &color : m_indexedColors) {
         writer.writeEmptyElement(QStringLiteral("rgbColor"));
         writer.writeAttribute(QStringLiteral("rgb"), XlsxColor::toARGBString(color));
     }

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -230,12 +230,12 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
         if (type == AbstractSheet::ST_WorkSheet) {
             do {
                 ++d->last_worksheet_index;
-                sheetName = QString("Sheet%1").arg(d->last_worksheet_index);
+                sheetName = QStringLiteral("Sheet%1").arg(d->last_worksheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else if (type == AbstractSheet::ST_ChartSheet) {
             do {
                 ++d->last_chartsheet_index;
-                sheetName = QString("Chart%1").arg(d->last_chartsheet_index);
+                sheetName = QStringLiteral("Chart%1").arg(d->last_chartsheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else {
             qWarning("unsupported sheet type.");
@@ -364,7 +364,7 @@ bool Workbook::copySheet(int index, const QString &newName)
         int copy_index = 1;
         do {
             ++copy_index;
-            worksheetName = QString("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
+            worksheetName = QStringLiteral("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
         } while (d->sheetNames.contains(worksheetName));
     }
 
@@ -501,11 +501,11 @@ void Workbook::saveToXmlFile(QIODevice *device) const
             writer.writeAttribute(QStringLiteral("state"), QStringLiteral("veryHidden"));
 
         if (sheet->sheetType() == AbstractSheet::ST_WorkSheet)
-            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QString("worksheets/sheet%1.xml").arg(++worksheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QStringLiteral("worksheets/sheet%1.xml").arg(++worksheetIndex));
         else
-            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QString("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QStringLiteral("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
 
-        writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+        writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
     }
     writer.writeEndElement();//sheets
 
@@ -513,15 +513,15 @@ void Workbook::saveToXmlFile(QIODevice *device) const
         writer.writeStartElement(QStringLiteral("externalReferences"));
         for (int i=0; i<d->externalLinks.size(); ++i) {
             writer.writeEmptyElement(QStringLiteral("externalReference"));
-            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QString("externalLinks/externalLink%1.xml").arg(i+1));
-            writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QStringLiteral("externalLinks/externalLink%1.xml").arg(i+1));
+            writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
         }
         writer.writeEndElement();//externalReferences
     }
 
     if (!d->definedNamesList.isEmpty()) {
         writer.writeStartElement(QStringLiteral("definedNames"));
-        foreach (XlsxDefineNameData data, d->definedNamesList) {
+        for (const XlsxDefineNameData &data : d->definedNamesList) {
             writer.writeStartElement(QStringLiteral("definedName"));
             writer.writeAttribute(QStringLiteral("name"), data.name);
             if (!data.comment.isEmpty())

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -115,7 +115,7 @@ void WorksheetPrivate::calculateSpans() const
 
 		if (row_num%16 == 0 || row_num == dimension.lastRow()) {
 			if (span_max != -1) {
-				row_spans[row_num / 16] = QString("%1:%2").arg(span_min).arg(span_max);
+                row_spans[row_num / 16] = QStringLiteral("%1:%2").arg(span_min).arg(span_max);
 				span_min = XLSX_COLUMN_MAX+1;
 				span_max = -1;
 			}
@@ -1326,7 +1326,7 @@ void Worksheet::saveToXmlFile(QIODevice *device) const
 	writer.writeEndElement();//sheetData
 
 	d->saveXmlMergeCells(writer);
-	foreach (const ConditionalFormatting cf, d->conditionalFormattingList)
+    for (const ConditionalFormatting &cf : d->conditionalFormattingList)
 		cf.saveToXml(writer);
 	d->saveXmlDataValidations(writer);
 
@@ -1751,7 +1751,7 @@ void WorksheetPrivate::saveXmlMergeCells(QXmlStreamWriter &writer) const
 	writer.writeStartElement(QStringLiteral("mergeCells"));
 	writer.writeAttribute(QStringLiteral("count"), QString::number(merges.size()));
 
-    foreach (CellRange range, merges)
+    for (const CellRange &range : merges)
     {
 		writer.writeEmptyElement(QStringLiteral("mergeCell"));
 		writer.writeAttribute(QStringLiteral("ref"), range.toString());
@@ -1768,7 +1768,7 @@ void WorksheetPrivate::saveXmlDataValidations(QXmlStreamWriter &writer) const
 	writer.writeStartElement(QStringLiteral("dataValidations"));
 	writer.writeAttribute(QStringLiteral("count"), QString::number(dataValidationsList.size()));
 
-	foreach (DataValidation validation, dataValidationsList)
+    for (const DataValidation &validation : dataValidationsList)
 		validation.saveToXml(writer);
 
 	writer.writeEndElement(); //dataValidations
@@ -1806,7 +1806,7 @@ void WorksheetPrivate::saveXmlHyperlinks(QXmlStreamWriter &writer) const
                 // Update relationships
 				relationships->addWorksheetRelationship(QStringLiteral("/hyperlink"), data->target, QStringLiteral("External"));
 
-				writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
+                writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
 			}
 
 			if (!data->location.isEmpty())
@@ -1838,10 +1838,10 @@ void WorksheetPrivate::saveXmlDrawings(QXmlStreamWriter &writer) const
 		return;
 
 	int idx = workbook->drawings().indexOf(drawing.data());
-	relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
+    relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
 
 	writer.writeEmptyElement(QStringLiteral("drawing"));
-	writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
 }
 
 void WorksheetPrivate::splitColsInfo(int colFirst, int colLast)
@@ -1970,8 +1970,8 @@ bool Worksheet::setColumnWidth(int colFirst, int colLast, double width)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
     {
 	   columnInfo->width = width;
     }
@@ -1988,8 +1988,8 @@ bool Worksheet::setColumnFormat(int colFirst, int colLast, const Format &format)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
 	   columnInfo->format = format;
 
 	if(columnInfoList.count() > 0) {
@@ -2008,8 +2008,8 @@ bool Worksheet::setColumnHidden(int colFirst, int colLast, bool hidden)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
 	   columnInfo->hidden = hidden;
 
 	return (columnInfoList.count() > 0);
@@ -2087,9 +2087,8 @@ bool Worksheet::setRowHeight(int rowFirst,int rowLast, double height)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList) {
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList) {
 		rowInfo->height = height;
 		rowInfo->customHeight = true;
 	}
@@ -2107,9 +2106,8 @@ bool Worksheet::setRowFormat(int rowFirst,int rowLast, const Format &format)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList)
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList)
 		rowInfo->format = format;
 
 	d->workbook->styles()->addXfFormat(format);
@@ -2126,8 +2124,8 @@ bool Worksheet::setRowHidden(int rowFirst,int rowLast, bool hidden)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList)
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList)
 		rowInfo->hidden = hidden;
 
 	return rowInfoList.count() > 0;
@@ -2687,7 +2685,7 @@ void WorksheetPrivate::loadXmlSheetFormatProps(QXmlStreamReader &reader)
     bool isSetWidth = false;
 
     // Retain default values
-    foreach (QXmlStreamAttribute attrib, attributes)
+    for  (const QXmlStreamAttribute &attrib : attributes)
     {
         if(attrib.name() == QLatin1String("baseColWidth") )
         {
@@ -2957,16 +2955,18 @@ void WorksheetPrivate::validateDimension()
 	int firstColumn = -1;
 	int lastColumn = -1;
 
-	for (QMap<int, QMap<int, QSharedPointer<Cell> > >::const_iterator it = cellTable.begin(); it != cellTable.end(); ++it)
-	{
-		Q_ASSERT(!it.value().isEmpty());
+    auto it = cellTable.constBegin();
+    while (it != cellTable.constEnd()) {
+        Q_ASSERT(!it.value().isEmpty());
 
-		if (firstColumn == -1 || it.value().constBegin().key() < firstColumn)
-			firstColumn = it.value().constBegin().key();
+        if (firstColumn == -1 || it.value().constBegin().key() < firstColumn)
+            firstColumn = it.value().constBegin().key();
 
-		if (lastColumn == -1 || (it.value().constEnd()-1).key() > lastColumn)
-			lastColumn = (it.value().constEnd()-1).key();
-	}
+        if (lastColumn == -1 || (it.value().constEnd()-1).key() > lastColumn)
+            lastColumn = (it.value().constEnd()-1).key();
+
+        ++it;
+    }
 
 	CellRange cr(firstRow, firstColumn, lastRow, lastColumn);
 

--- a/QXlsx/source/xlsxzipreader.cpp
+++ b/QXlsx/source/xlsxzipreader.cpp
@@ -49,11 +49,11 @@ ZipReader::~ZipReader()
 void ZipReader::init()
 {
 #if QT_VERSION >= 0x050600 // Qt 5.6 or over 
-    QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    const QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
 #else
-    QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    const QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
 #endif
-    foreach (const QZipReader::FileInfo &fi, allFiles) {
+    for (const QZipReader::FileInfo &fi : allFiles) {
         if (fi.isFile || (!fi.isDir && !fi.isFile && !fi.isSymLink))
             m_filePaths.append(fi.filePath);
     }


### PR DESCRIPTION
This disable CMake for checking for a C compiler.
Doesn't quietly fails if Qt is not found.
Add strict definitions for correct usage of
QStrings and disables the deprecated foreach
loops and other deprecated usage of Qt classes.