### PR TITLE
Optimize lookups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,23 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(QXlsx)
+project(QXlsx VERSION 1.0.0 LANGUAGES CXX)
 
-#------------------------------------------------------------------------------
-# Qt
-#------------------------------------------------------------------------------
-find_package(Qt5 REQUIRED QUIET COMPONENTS Core Gui)
+find_package(Qt5 5.6.0 REQUIRED COMPONENTS Core Gui)
 find_package(Qt5Gui CONFIG REQUIRED Private)
 set(CMAKE_AUTOMOC ON)
+
+add_definitions(
+    -DQT_NO_KEYWORDS
+    -DQT_NO_CAST_TO_ASCII
+    -DQT_NO_CAST_FROM_ASCII
+    -DQT_STRICT_ITERATORS
+    -DQT_NO_URL_CAST_FROM_STRING
+    -DQT_NO_CAST_FROM_BYTEARRAY
+    -DQT_USE_QSTRINGBUILDER
+    -DQT_NO_SIGNALS_SLOTS_KEYWORDS
+    -DQT_USE_FAST_OPERATOR_PLUS
+    -DQT_DISABLE_DEPRECATED_BEFORE=0x050c00
+)
 
 #------------------------------------------------------------------------------
 # Library

--- a/QXlsx/header/xlsxchart_p.h
+++ b/QXlsx/header/xlsxchart_p.h
@@ -22,10 +22,10 @@ class XlsxSeries
 {
 public:
     //At present, we care about number cell ranges only!
-    QString numberDataSource_numRef = ""; // yval, val
-    QString axDataSource_numRef = ""; // xval, cat
-    QString headerH_numRef = "";
-    QString headerV_numRef = "";
+    QString numberDataSource_numRef; // yval, val
+    QString axDataSource_numRef; // xval, cat
+    QString headerH_numRef;
+    QString headerV_numRef;
     bool    swapHeader = false;
 };
 
@@ -41,7 +41,7 @@ public:
               XlsxAxis::AxisPos p,
               int id,
               int crossId,
-              QString axisTitle = QString("") )
+              QString axisTitle = QString())
     {
         type = t;
         axisPos = p;

--- a/QXlsx/header/xlsxdocpropsapp_p.h
+++ b/QXlsx/header/xlsxdocpropsapp_p.h
@@ -39,7 +39,6 @@
 #include "xlsxglobal.h"
 #include "xlsxabstractooxmlfile.h"
 #include <QList>
-#include <QPair>
 #include <QStringList>
 #include <QMap>
 
@@ -64,7 +63,7 @@ public:
 
 private:
     QStringList m_titlesOfPartsList;
-    QList<QPair<QString, int> > m_headingPairsList;
+    QList<std::pair<QString, int> > m_headingPairsList;
     QMap<QString, QString> m_properties;
 };
 

--- a/QXlsx/source/xlsxcell.cpp
+++ b/QXlsx/source/xlsxcell.cpp
@@ -25,9 +25,13 @@ CellPrivate::CellPrivate(Cell *p) :
 }
 
 CellPrivate::CellPrivate(const CellPrivate * const cp)
-	: value(cp->value), formula(cp->formula), cellType(cp->cellType)
-	, format(cp->format), richString(cp->richString), parent(cp->parent),
-	styleNumber(cp->styleNumber)
+    : parent(cp->parent)
+    , cellType(cp->cellType)
+    , value(cp->value)
+    , formula(cp->formula)
+    , format(cp->format)
+    , richString(cp->richString)
+    , styleNumber(cp->styleNumber)
 {
 
 }
@@ -248,7 +252,7 @@ bool Cell::isDateTime() const
 
 	Cell::CellType cellType = d->cellType;
     double dValue = d->value.toDouble(); // number
-	QString strValue = d->value.toString().toUtf8(); 
+//	QString strValue = d->value.toString().toUtf8();
 	bool isValidFormat = d->format.isValid();
     bool isDateTimeFormat = d->format.isDateTimeFormat(); // datetime format
 

--- a/QXlsx/source/xlsxcellreference.cpp
+++ b/QXlsx/source/xlsxcellreference.cpp
@@ -50,7 +50,8 @@ QString col_to_name(int col_num)
 {
     static thread_local QMap<int, QString> col_cache;
 
-    if (!col_cache.contains(col_num)) {
+    auto it = col_cache.find(col_num);
+    if (it == col_cache.end()) {
         QString col_str;
         int remainder;
         while (col_num) {
@@ -60,10 +61,10 @@ QString col_to_name(int col_num)
             col_str.prepend(QChar('A'+remainder-1));
             col_num = (col_num - 1) / 26;
         }
-        col_cache.insert(col_num, col_str);
+        it = col_cache.insert(col_num, col_str);
     }
 
-    return col_cache[col_num];
+    return it.value();
 }
 
 int col_from_name(const QString &col_str)

--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -111,7 +111,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerH_numRef = "";
+                series->headerH_numRef = QString();
             }
             if( headerV )
             {
@@ -120,7 +120,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerV_numRef = "";
+                series->headerV_numRef = QString();
             }
             series->swapHeader = swapHeaders;
 
@@ -165,7 +165,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerH_numRef = "";
+                series->headerH_numRef = QString();
             }
 
             if( headerV )
@@ -175,7 +175,7 @@ void Chart::addSeries(const CellRange &range, AbstractSheet *sheet, bool headerH
             }
             else
             {
-                series->headerV_numRef = "";
+                series->headerV_numRef = QString();
             }
             series->swapHeader = swapHeaders;
 
@@ -1056,26 +1056,26 @@ void ChartPrivate::saveXmlChartLegend(QXmlStreamWriter &writer) const
             {
                 //case Chart::ChartAxisPos::Right:
                 case Chart::Right :
-                    pos = "r";
+                    pos = QStringLiteral("r");
                     break;
 
                 // case Chart::ChartAxisPos::Left:
                 case Chart::Left :
-                    pos = "l";
+                    pos = QStringLiteral("l");
                     break;
 
                 // case Chart::ChartAxisPos::Top:
                 case Chart::Top :
-                    pos = "t";
+                    pos = QStringLiteral("t");
                     break;
 
                 // case Chart::ChartAxisPos::Bottom:
                 case Chart::Bottom :
-                    pos = "b";
+                    pos = QStringLiteral("b");
                     break;
 
                 default:
-                    pos = "r";
+                    pos = QStringLiteral("r");
                     break;
             }
 
@@ -1143,7 +1143,7 @@ void ChartPrivate::saveXmlBarChart(QXmlStreamWriter &writer) const
 
 
     // Note: Bar3D have 2~3 axes
-    int axisListSize = axisList.size();
+    // int axisListSize = axisList.size();
     // [dev62]
     // Q_ASSERT( axisListSize == 2 ||
     //          ( axisListSize == 3 && chartType == Chart::CT_Bar3DChart ) );
@@ -1466,7 +1466,7 @@ bool ChartPrivate::loadXmlAxisValAx(QXmlStreamReader &reader)
 bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* axis)
 {
     Q_ASSERT( NULL != axis );
-    Q_ASSERT( reader.name().endsWith("Ax") );
+    Q_ASSERT( reader.name().endsWith(QLatin1String("Ax")) );
     QString name = reader.name().toString(); //
 
     while ( !reader.atEnd() )
@@ -1479,7 +1479,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             if ( reader.name() == QLatin1String("axId") ) // mandatory element
             {
                 // dev57
-                uint axId = reader.attributes().value("val").toString().toUInt(); // for Qt5.1
+                uint axId = reader.attributes().value(QStringLiteral("val")).toString().toUInt(); // for Qt5.1
                 axis->axisId = axId;
             }
             else if ( reader.name() == QLatin1String("scaling") )
@@ -1498,10 +1498,10 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
 
                 QString axPosVal = reader.attributes().value(QLatin1String("val")).toString();
 
-                if ( axPosVal == "l" ) { axis->axisPos = XlsxAxis::Left; }
-                else if ( axPosVal == "r" ) { axis->axisPos = XlsxAxis::Right; }
-                else if ( axPosVal == "t" ) { axis->axisPos = XlsxAxis::Top; }
-                else if ( axPosVal == "b" ) { axis->axisPos = XlsxAxis::Bottom; }
+                if ( axPosVal == QLatin1String("l") ) { axis->axisPos = XlsxAxis::Left; }
+                else if ( axPosVal == QLatin1String("r") ) { axis->axisPos = XlsxAxis::Right; }
+                else if ( axPosVal == QLatin1String("t") ) { axis->axisPos = XlsxAxis::Top; }
+                else if ( axPosVal == QLatin1String("b") ) { axis->axisPos = XlsxAxis::Bottom; }
             }
             else if ( reader.name() == QLatin1String("majorGridlines") )
             {
@@ -1592,7 +1592,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Scaling(QXmlStreamReader &reader, Xlsx
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "scaling" )
+                  reader.name() == QLatin1String("scaling") )
         {
             break;
         }
@@ -1661,7 +1661,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title(QXmlStreamReader &reader, XlsxAx
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "title" )
+                  reader.name() == QLatin1String("title") )
         {
             break;
         }
@@ -1682,7 +1682,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Overlay(QXmlStreamReader &reader
         {
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "overlay" )
+                  reader.name() == QLatin1String("overlay") )
         {
             break;
         }
@@ -1709,7 +1709,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx(QXmlStreamReader &reader, Xls
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "tx" )
+                  reader.name() == QLatin1String("tx") )
         {
             break;
         }
@@ -1736,7 +1736,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich(QXmlStreamReader &reader
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "rich" )
+                  reader.name() == QLatin1String("rich") )
         {
             break;
         }
@@ -1768,7 +1768,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P(QXmlStreamReader &read
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "p" )
+                  reader.name() == QLatin1String("p") )
         {
             break;
         }
@@ -1796,7 +1796,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_pPr(QXmlStreamReader &
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "pPr" )
+                  reader.name() == QLatin1String("pPr") )
         {
             break;
         }
@@ -1825,7 +1825,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared_Title_Tx_Rich_P_R(QXmlStreamReader &re
             }
         }
         else if ( reader.tokenType() == QXmlStreamReader::EndElement &&
-                  reader.name() == "r" )
+                  reader.name() == QLatin1String("r") )
         {
             break;
         }
@@ -1951,7 +1951,7 @@ void ChartPrivate::saveXmlAxisCatAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:catAx");
+    writer.writeStartElement(QStringLiteral("c:catAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -1985,7 +1985,7 @@ void ChartPrivate::saveXmlAxisDateAx(QXmlStreamWriter &writer, XlsxAxis* axis) c
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:dateAx");
+    writer.writeStartElement(QStringLiteral("c:dateAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2015,7 +2015,7 @@ void ChartPrivate::saveXmlAxisSerAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:serAx");
+    writer.writeStartElement(QStringLiteral("c:serAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2042,7 +2042,7 @@ void ChartPrivate::saveXmlAxisValAx(QXmlStreamWriter &writer, XlsxAxis* axis) co
 </xsd:complexType>
 */
 
-    writer.writeStartElement("c:valAx");
+    writer.writeStartElement(QStringLiteral("c:valAx"));
 
     saveXmlAxisEG_AxShared(writer, axis); // EG_AxShared
 
@@ -2100,11 +2100,11 @@ void ChartPrivate::saveXmlAxisEG_AxShared(QXmlStreamWriter &writer, XlsxAxis* ax
 
     if( majorGridlinesEnabled )
     {
-        writer.writeEmptyElement("c:majorGridlines");
+        writer.writeEmptyElement(QStringLiteral("c:majorGridlines"));
     }
     if( minorGridlinesEnabled )
     {
-        writer.writeEmptyElement("c:minorGridlines");
+        writer.writeEmptyElement(QStringLiteral("c:minorGridlines"));
     }
 
     saveXmlAxisEG_AxShared_Title(writer, axis); // "c:title" CT_Title
@@ -2159,28 +2159,28 @@ void ChartPrivate::saveXmlAxisEG_AxShared_Title(QXmlStreamWriter &writer, XlsxAx
     </xsd:complexType>
     */
 
-    writer.writeStartElement("c:title");
+    writer.writeStartElement(QStringLiteral("c:title"));
 
     // CT_Tx {{
-     writer.writeStartElement("c:tx");
+     writer.writeStartElement(QStringLiteral("c:tx"));
 
-      writer.writeStartElement("c:rich"); // CT_TextBody
+      writer.writeStartElement(QStringLiteral("c:rich")); // CT_TextBody
 
        writer.writeEmptyElement(QStringLiteral("a:bodyPr")); // CT_TextBodyProperties
 
        writer.writeEmptyElement(QStringLiteral("a:lstStyle")); // CT_TextListStyle
 
-       writer.writeStartElement("a:p");
+       writer.writeStartElement(QStringLiteral("a:p"));
 
-        writer.writeStartElement("a:pPr");
+        writer.writeStartElement(QStringLiteral("a:pPr"));
             writer.writeAttribute(QStringLiteral("lvl"), QString::number(0));
 
-            writer.writeStartElement("a:defRPr");
+            writer.writeStartElement(QStringLiteral("a:defRPr"));
             writer.writeAttribute(QStringLiteral("b"), QString::number(0));
             writer.writeEndElement(); // a:defRPr
         writer.writeEndElement(); // a:pPr
 
-        writer.writeStartElement("a:r");
+        writer.writeStartElement(QStringLiteral("a:r"));
         QString strAxisName = GetAxisName(axis);
         writer.writeTextElement( QStringLiteral("a:t"), strAxisName );
         writer.writeEndElement(); // a:r
@@ -2192,7 +2192,7 @@ void ChartPrivate::saveXmlAxisEG_AxShared_Title(QXmlStreamWriter &writer, XlsxAx
      writer.writeEndElement(); // c:tx
      // CT_Tx }}
 
-     writer.writeStartElement("c:overlay");
+     writer.writeStartElement(QStringLiteral("c:overlay"));
         writer.writeAttribute(QStringLiteral("val"), QString::number(0)); // CT_Boolean
      writer.writeEndElement(); // c:overlay
 
@@ -2248,13 +2248,13 @@ QString ChartPrivate::readSubTree(QXmlStreamReader &reader)
         {
             prefix = reader.prefix().toString();
 
-            treeString += QString("<" + reader.qualifiedName().toString() );
+            treeString += QLatin1String("<") + reader.qualifiedName().toString();
 
-            foreach(const QXmlStreamAttribute &attr, reader.attributes())
-            {
-                treeString += QString( " " + attr.name().toString() + "=\"" + attr.value().toString() + "\"");
+            const QXmlStreamAttributes attributes = reader.attributes();
+            for (const QXmlStreamAttribute &attr : attributes) {
+                treeString += QLatin1String(" ") + attr.name().toString() + QLatin1String("=\"") + attr.value().toString() + QLatin1String("\"");
             }
-            treeString += ">";
+            treeString += QStringLiteral(">");
         }
         else if (reader.tokenType() == QXmlStreamReader::EndElement )
         {
@@ -2262,7 +2262,7 @@ QString ChartPrivate::readSubTree(QXmlStreamReader &reader)
             {
                 break;
             }
-            treeString += QString("</" + reader.qualifiedName().toString() + ">");
+            treeString += QLatin1String("</") + reader.qualifiedName().toString() + QLatin1String(">");
         }
     }
 
@@ -2288,25 +2288,25 @@ bool ChartPrivate::loadXmlChartLegend(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("legendPos")) // c:legendPos
             {
                 QString pos = reader.attributes().value(QLatin1String("val")).toString();
-                if( pos.compare("r",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("r"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Right;
                     legendPos = Chart::Right;
                 }
                 else
-                if( pos.compare("l",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("l"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Left;
                     legendPos = Chart::Left;
                 }
                 else
-                if( pos.compare("t",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("t"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Top;
                     legendPos = Chart::Top;
                 }
                 else
-                if( pos.compare("b",Qt::CaseInsensitive) == 0)
+                if( pos.compare(QLatin1String("b"), Qt::CaseInsensitive) == 0)
                 {
                     // legendPos = Chart::ChartAxisPos::Bottom;
                     legendPos = Chart::Bottom;
@@ -2321,7 +2321,7 @@ bool ChartPrivate::loadXmlChartLegend(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("overlay")) // c:legendPos
             {
                 QString pos = reader.attributes().value(QLatin1String("val")).toString();
-                if( pos.compare("1",Qt::CaseInsensitive) == 0 )
+                if( pos.compare(QLatin1String("1"), Qt::CaseInsensitive) == 0 )
                 {
                     legendOverlay = true;
                 }

--- a/QXlsx/source/xlsxchartsheet.cpp
+++ b/QXlsx/source/xlsxchartsheet.cpp
@@ -106,10 +106,10 @@ void Chartsheet::saveToXmlFile(QIODevice *device) const
     writer.writeEndElement(); //sheetViews
 
     int idx = d->workbook->drawings().indexOf(d->drawing.data());
-    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
+    d->relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("drawing"));
-    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
 
     writer.writeEndElement();//chartsheet
     writer.writeEndDocument();

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -505,7 +505,7 @@ bool ConditionalFormattingPrivate::readCfRule(QXmlStreamReader &reader, XlsxCfRu
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("formula")) {
-                QString f = reader.readElementText();
+                const QString f = reader.readElementText();
                 if (!rule->attrs.contains(XlsxCfRuleData::A_formula1))
                     rule->attrs[XlsxCfRuleData::A_formula1] = f;
                 else if (!rule->attrs.contains(XlsxCfRuleData::A_formula2))
@@ -673,26 +673,46 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
         if (rule->dxfFormat.dxfIndexValid())
             writer.writeAttribute(QStringLiteral("dxfId"), QString::number(rule->dxfFormat.dxfIndex()));
         writer.writeAttribute(QStringLiteral("priority"), QString::number(rule->priority));
-        if (rule->attrs.contains(XlsxCfRuleData::A_stopIfTrue))
-            writer.writeAttribute(QStringLiteral("stopIfTrue"), rule->attrs[XlsxCfRuleData::A_stopIfTrue].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_aboveAverage))
-            writer.writeAttribute(QStringLiteral("aboveAverage"), rule->attrs[XlsxCfRuleData::A_aboveAverage].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_percent))
-            writer.writeAttribute(QStringLiteral("percent"), rule->attrs[XlsxCfRuleData::A_percent].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_bottom))
-            writer.writeAttribute(QStringLiteral("bottom"), rule->attrs[XlsxCfRuleData::A_bottom].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_operator))
-            writer.writeAttribute(QStringLiteral("operator"), rule->attrs[XlsxCfRuleData::A_operator].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_text))
-            writer.writeAttribute(QStringLiteral("text"), rule->attrs[XlsxCfRuleData::A_text].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_timePeriod))
-            writer.writeAttribute(QStringLiteral("timePeriod"), rule->attrs[XlsxCfRuleData::A_timePeriod].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_rank))
-            writer.writeAttribute(QStringLiteral("rank"), rule->attrs[XlsxCfRuleData::A_rank].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_stdDev))
-            writer.writeAttribute(QStringLiteral("stdDev"), rule->attrs[XlsxCfRuleData::A_stdDev].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_equalAverage))
-            writer.writeAttribute(QStringLiteral("equalAverage"), rule->attrs[XlsxCfRuleData::A_equalAverage].toString());
+
+        auto it = rule->attrs.constFind(XlsxCfRuleData::A_stopIfTrue);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("stopIfTrue"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_aboveAverage);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("aboveAverage"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_percent);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("percent"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_bottom);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("bottom"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_operator);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("operator"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_text);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("text"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_timePeriod);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("timePeriod"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_rank);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("rank"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_stdDev);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("stdDev"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_equalAverage);
+        if (it != rule->attrs.constEnd())
+            writer.writeAttribute(QStringLiteral("equalAverage"), it.value().toString());
 
         if (rule->attrs[XlsxCfRuleData::A_type] == QLatin1String("dataBar")) {
             writer.writeStartElement(QStringLiteral("dataBar"));
@@ -706,28 +726,37 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
             writer.writeStartElement(QStringLiteral("colorScale"));
             d->writeCfVo(writer, rule->attrs[XlsxCfRuleData::A_cfvo1].value<XlsxCfVoData>());
             d->writeCfVo(writer, rule->attrs[XlsxCfRuleData::A_cfvo2].value<XlsxCfVoData>());
-            if (rule->attrs.contains(XlsxCfRuleData::A_cfvo3))
-                d->writeCfVo(writer, rule->attrs[XlsxCfRuleData::A_cfvo3].value<XlsxCfVoData>());
+
+            it = rule->attrs.constFind(XlsxCfRuleData::A_cfvo3);
+            if (it != rule->attrs.constEnd())
+                d->writeCfVo(writer, it.value().value<XlsxCfVoData>());
 
             rule->attrs[XlsxCfRuleData::A_color1].value<XlsxColor>().saveToXml(writer);
             rule->attrs[XlsxCfRuleData::A_color2].value<XlsxColor>().saveToXml(writer);
-            if (rule->attrs.contains(XlsxCfRuleData::A_color3))
-                rule->attrs[XlsxCfRuleData::A_color3].value<XlsxColor>().saveToXml(writer);
+
+            it = rule->attrs.constFind(XlsxCfRuleData::A_color3);
+            if (it != rule->attrs.constEnd())
+                it.value().value<XlsxColor>().saveToXml(writer);
 
             writer.writeEndElement();//colorScale
         }
 
 
-        if (rule->attrs.contains(XlsxCfRuleData::A_formula1_temp)) {
+        it = rule->attrs.constFind(XlsxCfRuleData::A_formula1_temp);
+        if (it != rule->attrs.constEnd()) {
             QString startCell = ranges()[0].toString().split(QLatin1Char(':'))[0];
-            writer.writeTextElement(QStringLiteral("formula"), rule->attrs[XlsxCfRuleData::A_formula1_temp].toString().arg(startCell));
-        } else if (rule->attrs.contains(XlsxCfRuleData::A_formula1)) {
-            writer.writeTextElement(QStringLiteral("formula"), rule->attrs[XlsxCfRuleData::A_formula1].toString());
+            writer.writeTextElement(QStringLiteral("formula"), it.value().toString().arg(startCell));
+        } else if ((it = rule->attrs.constFind(XlsxCfRuleData::A_formula1)) != rule->attrs.constEnd()) {
+            writer.writeTextElement(QStringLiteral("formula"), it.value().toString());
         }
-        if (rule->attrs.contains(XlsxCfRuleData::A_formula2))
-            writer.writeTextElement(QStringLiteral("formula"), rule->attrs[XlsxCfRuleData::A_formula2].toString());
-        if (rule->attrs.contains(XlsxCfRuleData::A_formula3))
-            writer.writeTextElement(QStringLiteral("formula"), rule->attrs[XlsxCfRuleData::A_formula3].toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_formula2);
+        if (it != rule->attrs.constEnd())
+            writer.writeTextElement(QStringLiteral("formula"), it.value().toString());
+
+        it = rule->attrs.constFind(XlsxCfRuleData::A_formula3);
+        if (it != rule->attrs.constEnd())
+            writer.writeTextElement(QStringLiteral("formula"), it.value().toString());
 
         writer.writeEndElement(); //cfRule
     }

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -204,19 +204,19 @@ bool ConditionalFormatting::addHighlightCellsRule(HighlightRuleType type, const 
         if (type == Highlight_ContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("containsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("containsText");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("NOT(ISERROR(SEARCH(\"%1\",%2)))").arg(formula1);
         } else if (type == Highlight_NotContainsText) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("notContainsText");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("notContains");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("ISERROR(SEARCH(\"%2\",%1))").arg(formula1);
         } else if (type == Highlight_BeginsWith) {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("beginsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("beginsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("LEFT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         } else {
             cfRule->attrs[XlsxCfRuleData::A_type] = QStringLiteral("endsWith");
             cfRule->attrs[XlsxCfRuleData::A_operator] = QStringLiteral("endsWith");
-            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QString("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
+            cfRule->attrs[XlsxCfRuleData::A_formula1_temp] = QStringLiteral("RIGHT(%2,LEN(\"%1\"))=\"%1\"").arg(formula1);
         }
         cfRule->attrs[XlsxCfRuleData::A_text] = formula1;
         skipFormula = true;
@@ -631,9 +631,11 @@ bool ConditionalFormatting::loadFromXml(QXmlStreamReader &reader, Styles *styles
     d->ranges.clear();
     d->cfRules.clear();
     QXmlStreamAttributes attrs = reader.attributes();
-    QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    foreach (QString range, sqref.split(QLatin1Char(' ')))
+    const QString sqref = attrs.value(QLatin1String("sqref")).toString();
+    const auto sqrefParts = sqref.split(QLatin1Char(' '));
+    for (const QString &range : sqrefParts) {
         this->addRange(range);
+    }
 
     while (!reader.atEnd()) {
         reader.readNextStartElement();
@@ -658,8 +660,10 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("conditionalFormatting"));
     QStringList sqref;
-    foreach (CellRange range, ranges())
+    const auto rangeList = ranges();
+    for (const CellRange &range : rangeList) {
         sqref.append(range.toString());
+    }
     writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
     for (int i=0; i<d->cfRules.size(); ++i) {

--- a/QXlsx/source/xlsxcontenttypes.cpp
+++ b/QXlsx/source/xlsxcontenttypes.cpp
@@ -38,7 +38,7 @@ ContentTypes::ContentTypes(CreateFlag flag)
     m_package_prefix = QStringLiteral("application/vnd.openxmlformats-package.");
     m_document_prefix = QStringLiteral("application/vnd.openxmlformats-officedocument.");
 
-    m_defaults.insert(QStringLiteral("rels"), m_package_prefix + QStringLiteral("relationships+xml"));
+    m_defaults.insert(QStringLiteral("rels"), m_package_prefix + QLatin1String("relationships+xml"));
     m_defaults.insert(QStringLiteral("xml"), QStringLiteral("application/xml"));
 }
 
@@ -54,77 +54,77 @@ void ContentTypes::addOverride(const QString &key, const QString &value)
 
 void ContentTypes::addDocPropApp()
 {
-    addOverride(QStringLiteral("/docProps/app.xml"), m_document_prefix + QStringLiteral("extended-properties+xml"));
+    addOverride(QStringLiteral("/docProps/app.xml"), m_document_prefix + QLatin1String("extended-properties+xml"));
 }
 
 void ContentTypes::addDocPropCore()
 {
-    addOverride(QStringLiteral("/docProps/core.xml"), m_package_prefix + QStringLiteral("core-properties+xml"));
+    addOverride(QStringLiteral("/docProps/core.xml"), m_package_prefix + QLatin1String("core-properties+xml"));
 }
 
 void ContentTypes::addStyles()
 {
-    addOverride(QStringLiteral("/xl/styles.xml"), m_document_prefix + QStringLiteral("spreadsheetml.styles+xml"));
+    addOverride(QStringLiteral("/xl/styles.xml"), m_document_prefix + QLatin1String("spreadsheetml.styles+xml"));
 }
 
 void ContentTypes::addTheme()
 {
-    addOverride(QStringLiteral("/xl/theme/theme1.xml"), m_document_prefix + QStringLiteral("theme+xml"));
+    addOverride(QStringLiteral("/xl/theme/theme1.xml"), m_document_prefix + QLatin1String("theme+xml"));
 }
 
 void ContentTypes::addWorkbook()
 {
-    addOverride(QStringLiteral("/xl/workbook.xml"), m_document_prefix + QStringLiteral("spreadsheetml.sheet.main+xml"));
+    addOverride(QStringLiteral("/xl/workbook.xml"), m_document_prefix + QLatin1String("spreadsheetml.sheet.main+xml"));
 }
 
 void ContentTypes::addWorksheetName(const QString &name)
 {
-    addOverride(QString("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.worksheet+xml"));
+    addOverride(QStringLiteral("/xl/worksheets/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.worksheet+xml"));
 }
 
 void ContentTypes::addChartsheetName(const QString &name)
 {
-    addOverride(QString("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.chartsheet+xml"));
+    addOverride(QStringLiteral("/xl/chartsheets/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.chartsheet+xml"));
 }
 
 void ContentTypes::addDrawingName(const QString &name)
 {
-    addOverride(QString("/xl/drawings/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawing+xml"));
+    addOverride(QStringLiteral("/xl/drawings/%1.xml").arg(name), m_document_prefix + QLatin1String("drawing+xml"));
 }
 
 void ContentTypes::addChartName(const QString &name)
 {
-    addOverride(QString("/xl/charts/%1.xml").arg(name), m_document_prefix + QStringLiteral("drawingml.chart+xml"));
+    addOverride(QStringLiteral("/xl/charts/%1.xml").arg(name), m_document_prefix + QLatin1String("drawingml.chart+xml"));
 }
 
 void ContentTypes::addCommentName(const QString &name)
 {
-    addOverride(QString("/xl/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.comments+xml"));
+    addOverride(QStringLiteral("/xl/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.comments+xml"));
 }
 
 void ContentTypes::addTableName(const QString &name)
 {
-    addOverride(QString("/xl/tables/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.table+xml"));
+    addOverride(QStringLiteral("/xl/tables/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.table+xml"));
 }
 
 void ContentTypes::addExternalLinkName(const QString &name)
 {
-    addOverride(QString("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QStringLiteral("spreadsheetml.externalLink+xml"));
+    addOverride(QStringLiteral("/xl/externalLinks/%1.xml").arg(name), m_document_prefix + QLatin1String("spreadsheetml.externalLink+xml"));
 }
 
 void ContentTypes::addSharedString()
 {
-    addOverride(QStringLiteral("/xl/sharedStrings.xml"), m_document_prefix + QStringLiteral("spreadsheetml.sharedStrings+xml"));
+    addOverride(QStringLiteral("/xl/sharedStrings.xml"), m_document_prefix + QLatin1String("spreadsheetml.sharedStrings+xml"));
 }
 
 void ContentTypes::addVmlName()
 {
-    addOverride(QStringLiteral("vml"), m_document_prefix + QStringLiteral("vmlDrawing"));
+    addOverride(QStringLiteral("vml"), m_document_prefix + QLatin1String("vmlDrawing"));
 }
 
 void ContentTypes::addCalcChain()
 {
-    addOverride(QStringLiteral("/xl/calcChain.xml"), m_document_prefix + QStringLiteral("spreadsheetml.calcChain+xml"));
+    addOverride(QStringLiteral("/xl/calcChain.xml"), m_document_prefix + QLatin1String("spreadsheetml.calcChain+xml"));
 }
 
 void ContentTypes::addVbaProject()

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -503,15 +503,18 @@ DataValidation DataValidation::loadFromXml(QXmlStreamReader &reader)
 
     if (attrs.hasAttribute(QLatin1String("type"))) {
         QString t = attrs.value(QLatin1String("type")).toString();
-        validation.setValidationType(typeMap.contains(t) ? typeMap[t] : DataValidation::None);
+        auto it = typeMap.constFind(t);
+        validation.setValidationType(it != typeMap.constEnd() ? it.value() : DataValidation::None);
     }
     if (attrs.hasAttribute(QLatin1String("errorStyle"))) {
         QString es = attrs.value(QLatin1String("errorStyle")).toString();
-        validation.setErrorStyle(esMap.contains(es) ? esMap[es] : DataValidation::Stop);
+        auto it = esMap.constFind(es);
+        validation.setErrorStyle(it != esMap.constEnd() ? it.value() : DataValidation::Stop);
     }
     if (attrs.hasAttribute(QLatin1String("operator"))) {
         QString op = attrs.value(QLatin1String("operator")).toString();
-        validation.setValidationOperator(opMap.contains(op) ? opMap[op] : DataValidation::Between);
+        auto it = opMap.constFind(op);
+        validation.setValidationOperator(it != opMap.constEnd() ? it.value() : DataValidation::Between);
     }
     if (attrs.hasAttribute(QLatin1String("allowBlank"))) {
         validation.setAllowBlank(true);

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -443,7 +443,8 @@ bool DataValidation::saveToXml(QXmlStreamWriter &writer) const
         writer.writeAttribute(QStringLiteral("prompt"), promptMessage());
 
     QStringList sqref;
-    foreach (CellRange range, ranges())
+    const auto rangeList = ranges();
+    for (const CellRange &range : rangeList)
         sqref.append(range.toString());
     writer.writeAttribute(QStringLiteral("sqref"), sqref.join(QLatin1String(" ")));
 
@@ -496,7 +497,8 @@ DataValidation DataValidation::loadFromXml(QXmlStreamReader &reader)
     QXmlStreamAttributes attrs = reader.attributes();
 
     QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    foreach (QString range, sqref.split(QLatin1Char(' ')))
+    const auto sqrefParts = sqref.split(QLatin1Char(' '));
+    for (const QString &range : sqrefParts)
         validation.addRange(range);
 
     if (attrs.hasAttribute(QLatin1String("type"))) {

--- a/QXlsx/source/xlsxdocpropsapp.cpp
+++ b/QXlsx/source/xlsxdocpropsapp.cpp
@@ -68,8 +68,9 @@ bool DocPropsApp::setProperty(const QString &name, const QString &value)
 
 QString DocPropsApp::property(const QString &name) const
 {
-    if (m_properties.contains(name))
-        return m_properties[name];
+    auto it = m_properties.constFind(name);
+    if (it != m_properties.constEnd())
+        return it.value();
 
     return QString();
 }
@@ -117,10 +118,13 @@ void DocPropsApp::saveToXmlFile(QIODevice *device) const
     writer.writeEndElement();//vt:vector
     writer.writeEndElement();//TitlesOfParts
 
-    if (m_properties.contains(QStringLiteral("manager")))
-        writer.writeTextElement(QStringLiteral("Manager"), m_properties[QStringLiteral("manager")]);
+    auto it = m_properties.constFind(QStringLiteral("manager"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(QStringLiteral("Manager"), it.value());
     //Not like "manager", "company" always exists for Excel generated file.
-    writer.writeTextElement(QStringLiteral("Company"), m_properties.contains(QStringLiteral("company")) ? m_properties[QStringLiteral("company")]: QString());
+
+    it = m_properties.constFind(QStringLiteral("company"));
+    writer.writeTextElement(QStringLiteral("Company"), it != m_properties.constEnd() ? it.value() : QString());
     writer.writeTextElement(QStringLiteral("LinksUpToDate"), QStringLiteral("false"));
     writer.writeTextElement(QStringLiteral("SharedDoc"), QStringLiteral("false"));
     writer.writeTextElement(QStringLiteral("HyperlinksChanged"), QStringLiteral("false"));

--- a/QXlsx/source/xlsxdocpropsapp.cpp
+++ b/QXlsx/source/xlsxdocpropsapp.cpp
@@ -46,7 +46,7 @@ void DocPropsApp::addPartTitle(const QString &title)
 
 void DocPropsApp::addHeadingPair(const QString &name, int value)
 {
-    m_headingPairsList.append(qMakePair(name, value));
+    m_headingPairsList.append({ name, value });
 }
 
 bool DocPropsApp::setProperty(const QString &name, const QString &value)
@@ -96,8 +96,8 @@ void DocPropsApp::saveToXmlFile(QIODevice *device) const
     writer.writeStartElement(vt, QStringLiteral("vector"));
     writer.writeAttribute(QStringLiteral("size"), QString::number(m_headingPairsList.size()*2));
     writer.writeAttribute(QStringLiteral("baseType"), QStringLiteral("variant"));
-    typedef QPair<QString,int> PairType; //Make foreach happy
-    foreach (PairType pair, m_headingPairsList) {
+
+    for (const auto &pair : m_headingPairsList) {
         writer.writeStartElement(vt, QStringLiteral("variant"));
         writer.writeTextElement(vt, QStringLiteral("lpstr"), pair.first);
         writer.writeEndElement(); //vt:variant
@@ -112,7 +112,7 @@ void DocPropsApp::saveToXmlFile(QIODevice *device) const
     writer.writeStartElement(vt, QStringLiteral("vector"));
     writer.writeAttribute(QStringLiteral("size"), QString::number(m_titlesOfPartsList.size()));
     writer.writeAttribute(QStringLiteral("baseType"), QStringLiteral("lpstr"));
-    foreach (QString title, m_titlesOfPartsList)
+    for (const QString &title : m_titlesOfPartsList)
         writer.writeTextElement(vt, QStringLiteral("lpstr"), title);
     writer.writeEndElement();//vt:vector
     writer.writeEndElement();//TitlesOfParts

--- a/QXlsx/source/xlsxdocpropscore.cpp
+++ b/QXlsx/source/xlsxdocpropscore.cpp
@@ -61,8 +61,9 @@ bool DocPropsCore::setProperty(const QString &name, const QString &value)
 
 QString DocPropsCore::property(const QString &name) const
 {
-    if (m_properties.contains(name))
-        return m_properties[name];
+    auto it = m_properties.constFind(name);
+    if (it != m_properties.constEnd())
+        return it.value();
 
     return QString();
 }
@@ -88,25 +89,32 @@ void DocPropsCore::saveToXmlFile(QIODevice *device) const
     writer.writeNamespace(dcmitype, QStringLiteral("dcmitype"));
     writer.writeNamespace(xsi, QStringLiteral("xsi"));
 
-    if (m_properties.contains(QStringLiteral("title")))
-        writer.writeTextElement(dc, QStringLiteral("title"), m_properties[QStringLiteral("title")]);
+    auto it = m_properties.constFind(QStringLiteral("title"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(dc, QStringLiteral("title"), it.value());
 
-    if (m_properties.contains(QStringLiteral("subject")))
-        writer.writeTextElement(dc, QStringLiteral("subject"), m_properties[QStringLiteral("subject")]);
+    it = m_properties.constFind(QStringLiteral("subject"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(dc, QStringLiteral("subject"), it.value());
 
-    writer.writeTextElement(dc, QStringLiteral("creator"), m_properties.contains(QStringLiteral("creator")) ? m_properties[QStringLiteral("creator")] : QStringLiteral("Qt Xlsx Library"));
+    it = m_properties.constFind(QStringLiteral("creator"));
+    writer.writeTextElement(dc, QStringLiteral("creator"), it != m_properties.constEnd() ? it.value() : QStringLiteral("Qt Xlsx Library"));
 
-    if (m_properties.contains(QStringLiteral("keywords")))
-        writer.writeTextElement(cp, QStringLiteral("keywords"), m_properties[QStringLiteral("keywords")]);
+    it = m_properties.constFind(QStringLiteral("keywords"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(cp, QStringLiteral("keywords"), it.value());
 
-    if (m_properties.contains(QStringLiteral("description")))
-        writer.writeTextElement(dc, QStringLiteral("description"), m_properties[QStringLiteral("description")]);
+    it = m_properties.constFind(QStringLiteral("description"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(dc, QStringLiteral("description"), it.value());
 
-    writer.writeTextElement(cp, QStringLiteral("lastModifiedBy"), m_properties.contains(QStringLiteral("creator")) ? m_properties[QStringLiteral("creator")] : QStringLiteral("Qt Xlsx Library"));
+    it = m_properties.constFind(QStringLiteral("creator"));
+    writer.writeTextElement(cp, QStringLiteral("lastModifiedBy"), it != m_properties.constEnd() ? it.value() : QStringLiteral("Qt Xlsx Library"));
 
     writer.writeStartElement(dcterms, QStringLiteral("created"));
     writer.writeAttribute(xsi, QStringLiteral("type"), QStringLiteral("dcterms:W3CDTF"));
-    writer.writeCharacters(m_properties.contains(QStringLiteral("created")) ? m_properties[QStringLiteral("created")] : QDateTime::currentDateTime().toString(Qt::ISODate));
+    it = m_properties.constFind(QStringLiteral("created"));
+    writer.writeCharacters(it != m_properties.constEnd() ? it.value() : QDateTime::currentDateTime().toString(Qt::ISODate));
     writer.writeEndElement();//dcterms:created
 
     writer.writeStartElement(dcterms, QStringLiteral("modified"));
@@ -114,11 +122,13 @@ void DocPropsCore::saveToXmlFile(QIODevice *device) const
     writer.writeCharacters(QDateTime::currentDateTime().toString(Qt::ISODate));
     writer.writeEndElement();//dcterms:created
 
-    if (m_properties.contains(QStringLiteral("category")))
-        writer.writeTextElement(cp, QStringLiteral("category"), m_properties[QStringLiteral("category")]);
+    it = m_properties.constFind(QStringLiteral("category"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(cp, QStringLiteral("category"), it.value());
 
-    if (m_properties.contains(QStringLiteral("status")))
-        writer.writeTextElement(cp, QStringLiteral("contentStatus"), m_properties[QStringLiteral("status")]);
+    it = m_properties.constFind(QStringLiteral("status"));
+    if (it != m_properties.constEnd())
+        writer.writeTextElement(cp, QStringLiteral("contentStatus"), it.value());
 
     writer.writeEndElement(); //cp:coreProperties
     writer.writeEndDocument();

--- a/QXlsx/source/xlsxdocument.cpp
+++ b/QXlsx/source/xlsxdocument.cpp
@@ -1014,8 +1014,9 @@ CellRange Document::dimension() const
 QString Document::documentProperty(const QString &key) const
 {
 	Q_D(const Document);
-	if (d->documentProperties.contains(key))
-		return d->documentProperties[key];
+    auto it = d->documentProperties.constFind(key);
+    if (it != d->documentProperties.constEnd())
+        return it.value();
 	else
 		return QString();
 }

--- a/QXlsx/source/xlsxdocument.cpp
+++ b/QXlsx/source/xlsxdocument.cpp
@@ -195,7 +195,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
 		DocPropsCore props(DocPropsCore::F_LoadFromExists);
 		props.loadFromXmlData(zipReader.fileData(docPropsCore_Name));
-		foreach (QString name, props.propertyNames())
+        for (const QString &name : props.propertyNames())
 			q->setDocumentProperty(name, props.property(name));
 	}
 
@@ -208,7 +208,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
 		DocPropsApp props(DocPropsApp::F_LoadFromExists);
 		props.loadFromXmlData(zipReader.fileData(docPropsApp_Name));
-		foreach (QString name, props.propertyNames())
+        for (const QString &name : props.propertyNames())
 			q->setDocumentProperty(name, props.property(name));
 	}
 
@@ -234,7 +234,7 @@ bool DocumentPrivate::loadPackage(QIODevice *device)
 
         // dev34
         QString path;
-        if ( xlworkbook_Dir == "." ) // root
+        if ( xlworkbook_Dir == QLatin1String(".") ) // root
         {
             path = name;
         }
@@ -337,42 +337,42 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
     for (int i = 0 ; i < worksheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = worksheets[i];
-		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
+        contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QString("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/worksheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/worksheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	//save chartsheet xml files
 	QList<QSharedPointer<AbstractSheet> > chartsheets = workbook->getSheetsByTypes(AbstractSheet::ST_ChartSheet);
 	if (!chartsheets.isEmpty())
-		docPropsApp.addHeadingPair(QStringLiteral("Chartsheets"), chartsheets.size());
+        docPropsApp.addHeadingPair(QStringLiteral("Chartsheets"), chartsheets.size());
     for (int i=0; i<chartsheets.size(); ++i)
     {
 		QSharedPointer<AbstractSheet> sheet = chartsheets[i];
-		contentTypes->addWorksheetName(QString("sheet%1").arg(i+1));
+        contentTypes->addWorksheetName(QStringLiteral("sheet%1").arg(i+1));
 		docPropsApp.addPartTitle(sheet->sheetName());
 
-		zipWriter.addFile(QString("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/chartsheets/sheet%1.xml").arg(i+1), sheet->saveToXmlData());
 		Relationships *rel = sheet->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/chartsheets/_rels/sheet%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save external links xml files
     for (int i=0; i<workbook->d_func()->externalLinks.count(); ++i)
     {
 		SimpleOOXmlFile *link = workbook->d_func()->externalLinks[i].data();
-		contentTypes->addExternalLinkName(QString("externalLink%1").arg(i+1));
+        contentTypes->addExternalLinkName(QStringLiteral("externalLink%1").arg(i+1));
 
-		zipWriter.addFile(QString("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/externalLinks/externalLink%1.xml").arg(i+1), link->saveToXmlData());
 		Relationships *rel = link->relationships();
 		if (!rel->isEmpty())
-			zipWriter.addFile(QString("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/externalLinks/_rels/externalLink%1.xml.rels").arg(i+1), rel->saveToXmlData());
 	}
 
 	// save workbook xml file
@@ -383,16 +383,16 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save drawing xml files
     for (int i=0; i<workbook->drawings().size(); ++i)
     {
-		contentTypes->addDrawingName(QString("drawing%1").arg(i+1));
+        contentTypes->addDrawingName(QStringLiteral("drawing%1").arg(i+1));
 
 		Drawing *drawing = workbook->drawings()[i];
-		zipWriter.addFile(QString("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/drawings/drawing%1.xml").arg(i+1), drawing->saveToXmlData());
 		if (!drawing->relationships()->isEmpty())
-			zipWriter.addFile(QString("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
+            zipWriter.addFile(QStringLiteral("xl/drawings/_rels/drawing%1.xml.rels").arg(i+1), drawing->relationships()->saveToXmlData());
 	}
 
 	// save docProps app/core xml file
-	foreach (QString name, q->documentPropertyNames()) {
+    for (const QString &name : q->documentPropertyNames()) {
 		docPropsApp.setProperty(name, q->documentProperty(name));
 		docPropsCore.setProperty(name, q->documentProperty(name));
 	}
@@ -422,9 +422,9 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 	// save chart xml files
     for (int i=0; i<workbook->chartFiles().size(); ++i)
     {
-		contentTypes->addChartName(QString("chart%1").arg(i+1));
+        contentTypes->addChartName(QStringLiteral("chart%1").arg(i+1));
 		QSharedPointer<Chart> cf = workbook->chartFiles()[i];
-		zipWriter.addFile(QString("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
+        zipWriter.addFile(QStringLiteral("xl/charts/chart%1.xml").arg(i+1), cf->saveToXmlData());
 	}
 
 	// save image files
@@ -434,7 +434,7 @@ bool DocumentPrivate::savePackage(QIODevice *device) const
 		if (!mf->mimeType().isEmpty())
 			contentTypes->addDefault(mf->suffix(), mf->mimeType());
 
-		zipWriter.addFile(QString("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
+        zipWriter.addFile(QStringLiteral("xl/media/image%1.%2").arg(i+1).arg(mf->suffix()), mf->contents());
 	}
 
 	// save root .rels xml file
@@ -471,11 +471,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 
 	// copy all files from "to" zip except those related to style
 	for (int i = 0; i < toFilePaths.size(); i++) {
-		if (toFilePaths[i].contains("xl/styles")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/styles"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// style file exist in 'from' as well
 				// modify style file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy default theme style from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "dxfs");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -484,11 +484,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 			}
 		}
 
-		if (toFilePaths[i].contains("xl/workbook")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/workbook"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// workbook file exist in 'from' as well
 				// modify workbook file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy default theme style from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "workbookPr");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -496,11 +496,11 @@ bool DocumentPrivate::copyStyle(const QString &from, const QString &to)
 			}
 		}
 
-		if (toFilePaths[i].contains("xl/worksheets/sheet")) {
+        if (toFilePaths[i].contains(QLatin1String("xl/worksheets/sheet"))) {
 			if (filePaths.contains(toFilePaths[i])) {	// sheet file exist in 'from' as well
 				// modify sheet file
-				std::string fromData = QString(zipReader.fileData(toFilePaths[i])).toStdString();
-				std::string toData = QString(toReader->fileData(toFilePaths[i])).toStdString();
+                std::string fromData = QString::fromUtf8(zipReader.fileData(toFilePaths[i])).toStdString();
+                std::string toData = QString::fromUtf8(toReader->fileData(toFilePaths[i])).toStdString();
 				// copy "conditionalFormatting" from 'from' to 'to'
 				toData = xlsxDocumentCpp::copyTag(fromData, toData, "conditionalFormatting");
 				temporalZip.addFile(toFilePaths.at(i), QString::fromUtf8(toData.c_str()).toUtf8());
@@ -1254,14 +1254,14 @@ bool Document::changeimage(int filenoinmidea, QString newfile)
 	
 	const QString suffix = newfile.mid(newfile.lastIndexOf(QLatin1Char('.'))+1);
 	QString mimetypemy;
-	if(QString::compare("jpg", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/jpeg";
-	if(QString::compare("bmp", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/bmp";
-	if(QString::compare("gif", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/gif";
-	if(QString::compare("png", suffix, Qt::CaseInsensitive)==0)
-	   mimetypemy="image/png";
+    if(QString::compare(QLatin1String("jpg"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/jpeg");
+    if(QString::compare(QLatin1String("bmp"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/bmp");
+    if(QString::compare(QLatin1String("gif"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/gif");
+    if(QString::compare(QLatin1String("png"), suffix, Qt::CaseInsensitive)==0)
+       mimetypemy=QStringLiteral("image/png");
 	
 	QByteArray ba;
 	QBuffer buffer(&ba);
@@ -1332,7 +1332,7 @@ bool Document::autosizeColumnWidth(const CellRange &range)
 
     QMap<int, int> colWidth = getMaximalColumnWidth(range.firstRow(), range.lastRow());
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( (key >= range.firstColumn()) && (key <= range.lastColumn()) )
         {
@@ -1354,7 +1354,7 @@ bool Document::autosizeColumnWidth(int column)
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( key == column)
         {
@@ -1372,11 +1372,13 @@ bool Document::autosizeColumnWidth(int column)
  */
 bool Document::autosizeColumnWidth(int colFirst, int colLast)
 {
+    Q_UNUSED(colFirst)
+    Q_UNUSED(colLast)
     bool erg = false;
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         if( (key >= colFirst) && (key <= colLast) )
         {
@@ -1398,7 +1400,7 @@ bool Document::autosizeColumnWidth(void)
 
     QMap<int, int> colWidth = getMaximalColumnWidth();
 
-    foreach(int key, colWidth.keys())
+    for (int key : colWidth.keys())
     {
         erg |= setColumnWidth(key, colWidth.value(key));
     }

--- a/QXlsx/source/xlsxdrawing.cpp
+++ b/QXlsx/source/xlsxdrawing.cpp
@@ -55,7 +55,7 @@ void Drawing::saveToXmlFile(QIODevice *device) const
     writer.writeAttribute(QStringLiteral("xmlns:xdr"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"));
     writer.writeAttribute(QStringLiteral("xmlns:a"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/main"));
 
-    foreach (DrawingAnchor *anchor, anchors)
+    for (DrawingAnchor *anchor : anchors)
         anchor->saveToXml(writer);
 
     writer.writeEndElement();//xdr:wsDr

--- a/QXlsx/source/xlsxdrawinganchor.cpp
+++ b/QXlsx/source/xlsxdrawinganchor.cpp
@@ -741,7 +741,7 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvGraphicFramePr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id));
-    writer.writeAttribute(QStringLiteral("name"), QString("Chart %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QStringLiteral("Chart %1").arg(m_id));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvGraphicFramePr"));
     writer.writeEndElement();//xdr:nvGraphicFramePr
 
@@ -753,12 +753,12 @@ void DrawingAnchor::saveXmlObjectGraphicFrame(QXmlStreamWriter &writer) const
     writer.writeAttribute(QStringLiteral("uri"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
 
     int idx = m_drawing->workbook->chartFiles().indexOf(m_chartFile);
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QString("../charts/chart%1.xml").arg(idx+1));
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/chart"), QStringLiteral("../charts/chart%1.xml").arg(idx+1));
 
     writer.writeEmptyElement(QStringLiteral("c:chart"));
     writer.writeAttribute(QStringLiteral("xmlns:c"), QStringLiteral("http://schemas.openxmlformats.org/drawingml/2006/chart"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
 
     writer.writeEndElement(); //a:graphicData
     writer.writeEndElement(); //a:graphic
@@ -779,7 +779,7 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("xdr:nvPicPr"));
     writer.writeEmptyElement(QStringLiteral("xdr:cNvPr"));
     writer.writeAttribute(QStringLiteral("id"), QString::number(m_id+1)); // liufeijin
-    writer.writeAttribute(QStringLiteral("name"), QString("Picture %1").arg(m_id));
+    writer.writeAttribute(QStringLiteral("name"), QStringLiteral("Picture %1").arg(m_id));
 
     writer.writeStartElement(QStringLiteral("xdr:cNvPicPr"));
     writer.writeEmptyElement(QStringLiteral("a:picLocks"));
@@ -788,14 +788,14 @@ void DrawingAnchor::saveXmlObjectPicture(QXmlStreamWriter &writer) const
 
     writer.writeEndElement(); //xdr:nvPicPr
 
-    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2")
+    m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2")
                                                      .arg(m_pictureFile->index()+1)
                                                      .arg(m_pictureFile->suffix()));
 
     writer.writeStartElement(QStringLiteral("xdr:blipFill"));
     writer.writeEmptyElement(QStringLiteral("a:blip"));
     writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
-    writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));
+    writer.writeAttribute(QStringLiteral("r:embed"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));
     writer.writeStartElement(QStringLiteral("a:stretch"));
     writer.writeEmptyElement(QStringLiteral("a:fillRect"));
     writer.writeEndElement(); //a:stretch
@@ -852,13 +852,13 @@ void DrawingAnchor::saveXmlObjectShape(QXmlStreamWriter &writer) const
         writer.writeEndElement(); //a:prstGeom
 
     if(!m_pictureFile.isNull()){
-        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QString("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
+        m_drawing->relationships()->addDocumentRelationship(QStringLiteral("/image"), QStringLiteral("../media/image%1.%2").arg(m_pictureFile->index()+1).arg(m_pictureFile->suffix()));
         writer.writeStartElement(QStringLiteral("a:blipFill"));
         writer.writeAttribute(QStringLiteral("dpi"), QString::number(dpiTA));
         writer.writeAttribute(QStringLiteral("rotWithShape"),QString::number(rotWithShapeTA));
 
          writer.writeStartElement(QStringLiteral("a:blip"));
-           writer.writeAttribute(QStringLiteral("r:embed"), QString("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
+           writer.writeAttribute(QStringLiteral("r:embed"), QStringLiteral("rId%1").arg(m_drawing->relationships()->count()));  //sp_blip_rembed  QStringLiteral("rId%1").arg(m_drawing->relationships()->count()) can't made new pic
            writer.writeAttribute(QStringLiteral("xmlns:r"), QStringLiteral("http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
            if(!sp_blip_cstate.isNull()){
              writer.writeAttribute(QStringLiteral("cstate"), sp_blip_cstate);

--- a/QXlsx/source/xlsxformat.cpp
+++ b/QXlsx/source/xlsxformat.cpp
@@ -516,8 +516,9 @@ QByteArray Format::fontKey() const
 		QByteArray key;
 		QDataStream stream(&key, QIODevice::WriteOnly);
 		for (int i=FormatPrivate::P_Font_STARTID; i<FormatPrivate::P_Font_ENDID; ++i) {
-			if (d->properties.contains(i))
-				stream << i << d->properties[i];
+            auto it = d->properties.constFind(i);
+            if (it != d->properties.constEnd())
+                stream << i << it.value();
 		};
 
 		const_cast<Format*>(this)->d->font_key = key;
@@ -924,8 +925,9 @@ QByteArray Format::borderKey() const
 		QByteArray key;
 		QDataStream stream(&key, QIODevice::WriteOnly);
 		for (int i=FormatPrivate::P_Border_STARTID; i<FormatPrivate::P_Border_ENDID; ++i) {
-			if (d->properties.contains(i))
-				stream << i << d->properties[i];
+            auto it = d->properties.constFind(i);
+            if (it != d->properties.constEnd())
+                stream << i << it.value();
 		};
 
 		const_cast<Format*>(this)->d->border_key = key;
@@ -1044,8 +1046,9 @@ QByteArray Format::fillKey() const
 		QByteArray key;
 		QDataStream stream(&key, QIODevice::WriteOnly);
 		for (int i=FormatPrivate::P_Fill_STARTID; i<FormatPrivate::P_Fill_ENDID; ++i) {
-			if (d->properties.contains(i))
-				stream << i << d->properties[i];
+            auto it = d->properties.constFind(i);
+            if (it != d->properties.constEnd())
+                stream << i << it.value();
 		};
 
 		const_cast<Format*>(this)->d->fill_key = key;
@@ -1276,8 +1279,11 @@ int Format::theme() const
  */
 QVariant Format::property(int propertyId, const QVariant &defaultValue) const
 {
-	if (d && d->properties.contains(propertyId))
-		return d->properties[propertyId];
+    if (d) {
+        auto it = d->properties.constFind(propertyId);
+        if (it != d->properties.constEnd())
+            return it.value();
+    }
 	return defaultValue;
 }
 
@@ -1291,7 +1297,8 @@ void Format::setProperty(int propertyId, const QVariant &value, const QVariant &
 
     if (value != clearValue)
     {
-		if (d->properties.contains(propertyId) && d->properties[propertyId] == value)
+        auto it = d->properties.constFind(propertyId);
+        if (it != d->properties.constEnd() && it.value() == value)
 			return;
 
 		if (detach)

--- a/QXlsx/source/xlsxrelationships.cpp
+++ b/QXlsx/source/xlsxrelationships.cpp
@@ -82,7 +82,7 @@ void Relationships::addWorksheetRelationship(const QString &relativeType, const 
 QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 {
     QList<XlsxRelationship> res;
-    foreach (XlsxRelationship ship, m_relationships) {
+    for (const XlsxRelationship &ship : m_relationships) {
         if (ship.type == type)
             res.append(ship);
     }
@@ -92,7 +92,7 @@ QList<XlsxRelationship> Relationships::relationships(const QString &type) const
 void Relationships::addRelationship(const QString &type, const QString &target, const QString &targetMode)
 {
     XlsxRelationship relation;
-    relation.id = QString("rId%1").arg(m_relationships.size()+1);
+    relation.id = QStringLiteral("rId%1").arg(m_relationships.size()+1);
     relation.type = type;
     relation.target = target;
     relation.targetMode = targetMode;
@@ -107,7 +107,7 @@ void Relationships::saveToXmlFile(QIODevice *device) const
     writer.writeStartDocument(QStringLiteral("1.0"), true);
     writer.writeStartElement(QStringLiteral("Relationships"));
     writer.writeAttribute(QStringLiteral("xmlns"), QStringLiteral("http://schemas.openxmlformats.org/package/2006/relationships"));
-    foreach (XlsxRelationship relation, m_relationships) {
+    for (const XlsxRelationship &relation : m_relationships) {
         writer.writeStartElement(QStringLiteral("Relationship"));
         writer.writeAttribute(QStringLiteral("Id"), relation.id);
         writer.writeAttribute(QStringLiteral("Type"), relation.type);
@@ -164,7 +164,7 @@ bool Relationships::loadFromXmlData(const QByteArray &data)
 
 XlsxRelationship Relationships::getRelationshipById(const QString &id) const
 {
-    foreach (XlsxRelationship ship, m_relationships) {
+    for (const XlsxRelationship &ship : m_relationships) {
         if (ship.id == id)
             return ship;
     }

--- a/QXlsx/source/xlsxrichstring.cpp
+++ b/QXlsx/source/xlsxrichstring.cpp
@@ -130,7 +130,7 @@ bool RichString::isNull() const
  */
 bool RichString::isEmtpy() const
 {
-    foreach (const QString str, d->fragmentTexts) {
+    for (const QString str : d->fragmentTexts) {
         if (!str.isEmpty())
             return false;
     }

--- a/QXlsx/source/xlsxsharedstrings.cpp
+++ b/QXlsx/source/xlsxsharedstrings.cpp
@@ -48,10 +48,10 @@ int SharedStrings::addSharedString(const RichString &string)
 {
     m_stringCount += 1;
 
-    if (m_stringTable.contains(string)) {
-        XlsxSharedStringInfo &item = m_stringTable[string];
-        item.count += 1;
-        return item.index;
+    auto it = m_stringTable.find(string);
+    if (it != m_stringTable.end()) {
+        it->count += 1;
+        return it->index;
     }
 
     int index = m_stringList.size();
@@ -83,19 +83,19 @@ void SharedStrings::removeSharedString(const QString &string)
  */
 void SharedStrings::removeSharedString(const RichString &string)
 {
-    if (!m_stringTable.contains(string))
+    auto it = m_stringTable.find(string);
+    if (it == m_stringTable.end())
         return;
 
     m_stringCount -= 1;
 
-    XlsxSharedStringInfo &item = m_stringTable[string];
-    item.count -= 1;
+    it->count -= 1;
 
-    if (item.count <= 0) {
-        for (int i=item.index+1; i<m_stringList.size(); ++i)
+    if (it->count <= 0) {
+        for (int i=it->index+1; i<m_stringList.size(); ++i)
             m_stringTable[m_stringList[i]].index -= 1;
 
-        m_stringList.removeAt(item.index);
+        m_stringList.removeAt(it->index);
         m_stringTable.remove(string);
     }
 }
@@ -107,8 +107,9 @@ int SharedStrings::getSharedStringIndex(const QString &string) const
 
 int SharedStrings::getSharedStringIndex(const RichString &string) const
 {
-    if (m_stringTable.contains(string))
-        return m_stringTable[string].index;
+    auto it = m_stringTable.constFind(string);
+    if (it != m_stringTable.constEnd())
+        return it->index;
     return -1;
 }
 

--- a/QXlsx/source/xlsxsharedstrings.cpp
+++ b/QXlsx/source/xlsxsharedstrings.cpp
@@ -203,7 +203,7 @@ void SharedStrings::saveToXmlFile(QIODevice *device) const
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_stringCount));
     writer.writeAttribute(QStringLiteral("uniqueCount"), QString::number(m_stringList.size()));
 
-    foreach (RichString string, m_stringList) {
+    for (const RichString &string : m_stringList) {
         writer.writeStartElement(QStringLiteral("si"));
         if (string.isRichString()) {
             //Rich text string

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -133,14 +133,16 @@ void Styles::fixNumFmt(const Format &format)
     const QString str = format.numberFormat();
     if (!str.isEmpty())
     {
+        QHash<QString, QSharedPointer<XlsxFormatNumberData> >::ConstIterator cIt;
         //Assign proper number format index
-        if ( m_builtinNumFmtsHash.contains(str) )
+        auto it = m_builtinNumFmtsHash.constFind(str);
+        if (it != m_builtinNumFmtsHash.constEnd())
         {
-            const_cast<Format *>(&format)->fixNumberFormat(m_builtinNumFmtsHash[str], str);
+            const_cast<Format *>(&format)->fixNumberFormat(it.value(), str);
         }
-        else if (m_customNumFmtsHash.contains(str))
+        else if ((cIt = m_customNumFmtsHash.constFind(str)) != m_customNumFmtsHash.constEnd())
         {
-            const_cast<Format *>(&format)->fixNumberFormat(m_customNumFmtsHash[str]->formatIndex, str);
+            const_cast<Format *>(&format)->fixNumberFormat(cIt.value()->formatIndex, str);
         }
         else
         {
@@ -160,26 +162,27 @@ void Styles::fixNumFmt(const Format &format)
     {
         int id = format.numberFormatIndex();
         //Assign proper format code, this is needed by dxf format
-        if (m_customNumFmtIdMap.contains(id))
+        auto it = m_customNumFmtIdMap.constFind(id);
+        if (it != m_customNumFmtIdMap.constEnd())
         {
-            const_cast<Format *>(&format)->fixNumberFormat(id, m_customNumFmtIdMap[id]->formatString);
+            const_cast<Format *>(&format)->fixNumberFormat(id, it.value()->formatString);
         }
         else
         {
-            QHashIterator<QString, int> it(m_builtinNumFmtsHash);
-            bool find = false;
-            while (it.hasNext())
+            bool found = false;
+            auto it = m_builtinNumFmtsHash.constBegin();
+            while (it != m_builtinNumFmtsHash.constEnd())
             {
-                it.next();
                 if (it.value() == id)
                 {
                     const_cast<Format *>(&format)->fixNumberFormat(id, it.key());
-                    find = true;
+                    found = true;
                     break;
                 }
+                ++it;
             }
 
-            if (!find)
+            if (!found)
             {
                 //Wrong numFmt
                 const_cast<Format *>(&format)->fixNumberFormat(id, QStringLiteral("General"));
@@ -214,16 +217,16 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Font
+    auto fontIt = m_fontsHash.constFind(format.fontKey());
     if (format.hasFontData() && !format.fontIndexValid())
     {
         //Assign proper font index, if has font data.
-        if (!m_fontsHash.contains(format.fontKey()))
+        if (fontIt == m_fontsHash.constEnd())
             const_cast<Format *>(&format)->setFontIndex(m_fontsList.size());
         else
-            const_cast<Format *>(&format)->setFontIndex(m_fontsHash[format.fontKey()].fontIndex());
+            const_cast<Format *>(&format)->setFontIndex(fontIt->fontIndex());
     }
-
-    if (!m_fontsHash.contains(format.fontKey()))
+    if (fontIt == m_fontsHash.constEnd())
     {
         //Still a valid font if the format has no fontData. (All font properties are default)
         m_fontsList.append(format);
@@ -231,43 +234,46 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Fill
+    auto fillIt = m_fillsHash.constFind(format.fillKey());
     if (format.hasFillData() && !format.fillIndexValid()) {
         //Assign proper fill index, if has fill data.
-        if (!m_fillsHash.contains(format.fillKey()))
+        if (fillIt == m_fillsHash.constEnd())
             const_cast<Format *>(&format)->setFillIndex(m_fillsList.size());
         else
-            const_cast<Format *>(&format)->setFillIndex(m_fillsHash[format.fillKey()].fillIndex());
+            const_cast<Format *>(&format)->setFillIndex(fillIt->fillIndex());
     }
-    if (!m_fillsHash.contains(format.fillKey())) {
+    if (fillIt == m_fillsHash.constEnd()) {
         //Still a valid fill if the format has no fillData. (All fill properties are default)
         m_fillsList.append(format);
         m_fillsHash[format.fillKey()] = format;
     }
 
     //Border
+    auto borderIt = m_bordersHash.constFind(format.borderKey());
     if (format.hasBorderData() && !format.borderIndexValid()) {
         //Assign proper border index, if has border data.
-        if (!m_bordersHash.contains(format.borderKey()))
+        if (borderIt == m_bordersHash.constEnd())
             const_cast<Format *>(&format)->setBorderIndex(m_bordersList.size());
         else
-            const_cast<Format *>(&format)->setBorderIndex(m_bordersHash[format.borderKey()].borderIndex());
+            const_cast<Format *>(&format)->setBorderIndex(borderIt->borderIndex());
     }
-    if (!m_bordersHash.contains(format.borderKey())) {
+    if (borderIt == m_bordersHash.constEnd()) {
         //Still a valid border if the format has no borderData. (All border properties are default)
         m_bordersList.append(format);
         m_bordersHash[format.borderKey()] = format;
     }
 
     //Format
+    auto formatIt = m_xf_formatsHash.constFind(format.formatKey());
     if (!format.isEmpty() && !format.xfIndexValid())
     {
-        if (m_xf_formatsHash.contains(format.formatKey()))
-            const_cast<Format *>(&format)->setXfIndex(m_xf_formatsHash[format.formatKey()].xfIndex());
-        else
+        if (formatIt == m_xf_formatsHash.constEnd())
             const_cast<Format *>(&format)->setXfIndex(m_xf_formatsList.size());
+        else
+            const_cast<Format *>(&format)->setXfIndex(formatIt->xfIndex());
     }
 
-    if (!m_xf_formatsHash.contains(format.formatKey()) ||
+    if (formatIt == m_xf_formatsHash.constEnd() ||
             force)
     {
         m_xf_formatsList.append(format);
@@ -283,20 +289,21 @@ void Styles::addDxfFormat(const Format &format, bool force)
         fixNumFmt(format);
     }
 
+    auto formatIt = m_dxf_formatsHash.constFind(format.formatKey());
     if ( !format.isEmpty() &&
             !format.dxfIndexValid() )
     {
-        if (m_dxf_formatsHash.contains(format.formatKey()))
-        {
-            const_cast<Format *>(&format)->setDxfIndex( m_dxf_formatsHash[format.formatKey()].dxfIndex() );
-        }
-        else
+        if (formatIt == m_xf_formatsHash.constEnd())
         {
             const_cast<Format *>(&format)->setDxfIndex( m_dxf_formatsList.size() );
         }
+        else
+        {
+            const_cast<Format *>(&format)->setDxfIndex( formatIt->dxfIndex() );
+        }
     }
 
-    if ( !m_dxf_formatsHash.contains(format.formatKey()) ||
+    if (formatIt == m_xf_formatsHash.constEnd() ||
          force )
     {
         m_dxf_formatsList.append(format);
@@ -910,8 +917,8 @@ bool Styles::readFill(QXmlStreamReader &reader, Format &fill)
             if (reader.name() == QLatin1String("patternFill")) {
                 QXmlStreamAttributes attributes = reader.attributes();
                 if (attributes.hasAttribute(QLatin1String("patternType"))) {
-                    QString pattern = attributes.value(QLatin1String("patternType")).toString();
-                    fill.setFillPattern(patternValues.contains(pattern) ? patternValues[pattern] : Format::PatternNone);
+                    auto it = patternValues.constFind(attributes.value(QLatin1String("patternType")).toString());
+                    fill.setFillPattern(it != patternValues.constEnd() ? it.value() : Format::PatternNone);
 
                     //parse foreground and background colors if they exist
                     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement && reader.name() == QLatin1String("patternFill"))) {
@@ -1062,9 +1069,10 @@ bool Styles::readSubBorder(QXmlStreamReader &reader, const QString &name, Format
     QXmlStreamAttributes attributes = reader.attributes();
     if (attributes.hasAttribute(QLatin1String("style"))) {
         QString styleString = attributes.value(QLatin1String("style")).toString();
-        if (stylesStringsMap.contains(styleString)) {
+        auto it = stylesStringsMap.constFind(styleString);
+        if (it != stylesStringsMap.constEnd()) {
             //get style
-            style = stylesStringsMap[styleString];
+            style = it.value();
             while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement && reader.name() == name)) {
                 reader.readNextStartElement();
                 if (reader.tokenType() == QXmlStreamReader::StartElement) {
@@ -1101,10 +1109,11 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                     int numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toString().toInt();
                     bool apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyNumberFormat")).toString());
                     if(apply) {
-                        if (!m_customNumFmtIdMap.contains(numFmtIndex))
+                        auto it = m_customNumFmtIdMap.constFind(numFmtIndex);
+                        if (it == m_customNumFmtIdMap.constEnd())
                             format.setNumberFormatIndex(numFmtIndex);
                         else
-                            format.setNumberFormat(numFmtIndex, m_customNumFmtIdMap[numFmtIndex]->formatString);
+                            format.setNumberFormat(numFmtIndex, it.value()->formatString);
                     }
                 }
 
@@ -1180,9 +1189,10 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                                 {QStringLiteral("centerContinuous"), Format::AlignHMerge},
                                 {QStringLiteral("distributed"), Format::AlignHDistributed}
                             };
-                            QString str = alignAttrs.value(QLatin1String("horizontal")).toString();
-                            if (alignStringMap.contains(str))
-                                format.setHorizontalAlignment(alignStringMap[str]);
+
+                            auto it = alignStringMap.constFind(alignAttrs.value(QLatin1String("horizontal")).toString());
+                            if (it != alignStringMap.constEnd())
+                                format.setHorizontalAlignment(it.value());
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("vertical"))) {
@@ -1192,9 +1202,10 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                                 {QStringLiteral("justify"), Format::AlignVJustify},
                                 {QStringLiteral("distributed"), Format::AlignVDistributed}
                             };
-                            QString str = alignAttrs.value(QLatin1String("vertical")).toString();
-                            if (alignStringMap.contains(str))
-                                format.setVerticalAlignment(alignStringMap[str]);
+
+                            auto it = alignStringMap.constFind(alignAttrs.value(QLatin1String("vertical")).toString());
+                            if (it != alignStringMap.constEnd())
+                                format.setVerticalAlignment(it.value());
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("indent"))) {

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -597,7 +597,7 @@ void Styles::writeCellXfs(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("cellXfs"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_xf_formatsList.size()));
-    foreach (const Format &format, m_xf_formatsList) {
+    for (const Format &format : m_xf_formatsList) {
         int xf_id = 0;
         writer.writeStartElement(QStringLiteral("xf"));
         writer.writeAttribute(QStringLiteral("numFmtId"), QString::number(format.numberFormatIndex()));
@@ -683,7 +683,7 @@ void Styles::writeDxfs(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("dxfs"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_dxf_formatsList.size()));
-    foreach (const Format &format, m_dxf_formatsList)
+    for (const Format &format : m_dxf_formatsList)
         writeDxf(writer, format);
     writer.writeEndElement(); //dxfs
 }
@@ -718,7 +718,7 @@ void Styles::writeColors(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("colors"));
 
     writer.writeStartElement(QStringLiteral("indexedColors"));
-    foreach(QColor color, m_indexedColors) {
+    for (const QColor &color : m_indexedColors) {
         writer.writeEmptyElement(QStringLiteral("rgbColor"));
         writer.writeAttribute(QStringLiteral("rgb"), XlsxColor::toARGBString(color));
     }

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -230,12 +230,12 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
         if (type == AbstractSheet::ST_WorkSheet) {
             do {
                 ++d->last_worksheet_index;
-                sheetName = QString("Sheet%1").arg(d->last_worksheet_index);
+                sheetName = QStringLiteral("Sheet%1").arg(d->last_worksheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else if (type == AbstractSheet::ST_ChartSheet) {
             do {
                 ++d->last_chartsheet_index;
-                sheetName = QString("Chart%1").arg(d->last_chartsheet_index);
+                sheetName = QStringLiteral("Chart%1").arg(d->last_chartsheet_index);
             } while (d->sheetNames.contains(sheetName));
         } else {
             qWarning("unsupported sheet type.");
@@ -364,7 +364,7 @@ bool Workbook::copySheet(int index, const QString &newName)
         int copy_index = 1;
         do {
             ++copy_index;
-            worksheetName = QString("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
+            worksheetName = QStringLiteral("%1(%2)").arg(d->sheets[index]->sheetName()).arg(copy_index);
         } while (d->sheetNames.contains(worksheetName));
     }
 
@@ -501,11 +501,11 @@ void Workbook::saveToXmlFile(QIODevice *device) const
             writer.writeAttribute(QStringLiteral("state"), QStringLiteral("veryHidden"));
 
         if (sheet->sheetType() == AbstractSheet::ST_WorkSheet)
-            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QString("worksheets/sheet%1.xml").arg(++worksheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/worksheet"), QStringLiteral("worksheets/sheet%1.xml").arg(++worksheetIndex));
         else
-            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QString("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
+            d->relationships->addDocumentRelationship(QStringLiteral("/chartsheet"), QStringLiteral("chartsheets/sheet%1.xml").arg(++chartsheetIndex));
 
-        writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+        writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
     }
     writer.writeEndElement();//sheets
 
@@ -513,15 +513,15 @@ void Workbook::saveToXmlFile(QIODevice *device) const
         writer.writeStartElement(QStringLiteral("externalReferences"));
         for (int i=0; i<d->externalLinks.size(); ++i) {
             writer.writeEmptyElement(QStringLiteral("externalReference"));
-            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QString("externalLinks/externalLink%1.xml").arg(i+1));
-            writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(d->relationships->count()));
+            d->relationships->addDocumentRelationship(QStringLiteral("/externalLink"), QStringLiteral("externalLinks/externalLink%1.xml").arg(i+1));
+            writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(d->relationships->count()));
         }
         writer.writeEndElement();//externalReferences
     }
 
     if (!d->definedNamesList.isEmpty()) {
         writer.writeStartElement(QStringLiteral("definedNames"));
-        foreach (XlsxDefineNameData data, d->definedNamesList) {
+        for (const XlsxDefineNameData &data : d->definedNamesList) {
             writer.writeStartElement(QStringLiteral("definedName"));
             writer.writeAttribute(QStringLiteral("name"), data.name);
             if (!data.comment.isEmpty())

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -82,9 +82,10 @@ void WorksheetPrivate::calculateSpans() const
 	int span_max = -1;
 
 	for (int row_num = dimension.firstRow(); row_num <= dimension.lastRow(); row_num++) {
-		if (cellTable.contains(row_num)) {
+        auto it = cellTable.constFind(row_num);
+        if (it != cellTable.constEnd()) {
 			for (int col_num = dimension.firstColumn(); col_num <= dimension.lastColumn(); col_num++) {
-				if (cellTable[row_num].contains(col_num)) {
+                if (it->contains(col_num)) {
 					if (span_max == -1) {
 						span_min = col_num;
 						span_max = col_num;
@@ -97,9 +98,10 @@ void WorksheetPrivate::calculateSpans() const
 				}
 			}
 		}
-		if (comments.contains(row_num)) {
+        auto cIt = comments.constFind(row_num);
+        if (cIt != comments.constEnd()) {
 			for (int col_num = dimension.firstColumn(); col_num <= dimension.lastColumn(); col_num++) {
-				if (comments[row_num].contains(col_num)) {
+                if (cIt->contains(col_num)) {
 					if (span_max == -1) {
 						span_min = col_num;
 						span_max = col_num;
@@ -588,24 +590,26 @@ Cell *Worksheet::cellAt(const CellReference &row_column) const
  * Returns the cell at the given \a row and \a column. If there
  * is no cell at the specified position, the function returns 0.
  */
-Cell *Worksheet::cellAt(int row, int column) const
+Cell *Worksheet::cellAt(int row, int col) const
 {
 	Q_D(const Worksheet);
-	if (!d->cellTable.contains(row))
+    auto it = d->cellTable.constFind(row);
+    if (it == d->cellTable.constEnd())
 		return 0;
-	if (!d->cellTable[row].contains(column))
+    if (!it->contains(col))
 		return 0;
 
-	return d->cellTable[row][column].data();
+    return (*it)[col].data();
 }
 
 Format WorksheetPrivate::cellFormat(int row, int col) const
 {
-	if (!cellTable.contains(row))
+    auto it = cellTable.constFind(row);
+    if (it == cellTable.constEnd())
 		return Format();
-	if (!cellTable[row].contains(col))
+    if (!it->contains(col))
 		return Format();
-	return cellTable[row][col]->format();
+    return (*it)[col]->format();
 }
 
 /*!
@@ -1189,12 +1193,8 @@ bool Worksheet::mergeCells(const CellRange &range, const Format &format)
 */
 bool Worksheet::unmergeCells(const CellRange &range)
 {
-	Q_D(Worksheet);
-	if (!d->merges.contains(range))
-		return false;
-
-	d->merges.removeOne(range);
-	return true;
+    Q_D(Worksheet);
+    return d->merges.removeOne(range);
 }
 
 /*!
@@ -1456,7 +1456,9 @@ void WorksheetPrivate::saveXmlSheetData(QXmlStreamWriter &writer) const
 	calculateSpans();
     for (int row_num = dimension.firstRow(); row_num <= dimension.lastRow(); row_num++)
     {
-        if (!(cellTable.contains(row_num) || comments.contains(row_num) || rowsInfo.contains(row_num)))
+        auto ctIt = cellTable.constFind(row_num);
+        auto riIt = rowsInfo.constFind(row_num);
+        if (ctIt == cellTable.constEnd() && riIt == rowsInfo.constEnd() && !comments.contains(row_num))
         {
 			//Only process rows with cell data / comments / formatting
 			continue;
@@ -1464,8 +1466,9 @@ void WorksheetPrivate::saveXmlSheetData(QXmlStreamWriter &writer) const
 
 		int span_index = (row_num-1) / 16;
 		QString span;
-		if (row_spans.contains(span_index))
-			span = row_spans[span_index];
+        auto rsIt = row_spans.constFind(span_index);
+        if (rsIt != row_spans.constEnd())
+            span = rsIt.value();
 
 		writer.writeStartElement(QStringLiteral("row"));
 		writer.writeAttribute(QStringLiteral("r"), QString::number(row_num));
@@ -1473,9 +1476,9 @@ void WorksheetPrivate::saveXmlSheetData(QXmlStreamWriter &writer) const
 		if (!span.isEmpty())
 			writer.writeAttribute(QStringLiteral("spans"), span);
 
-        if (rowsInfo.contains(row_num))
+        if (riIt != rowsInfo.constEnd())
         {
-			QSharedPointer<XlsxRowInfo> rowInfo = rowsInfo[row_num];
+            QSharedPointer<XlsxRowInfo> rowInfo = riIt.value();
             if (!rowInfo->format.isEmpty())
             {
 				writer.writeAttribute(QStringLiteral("s"), QString::number(rowInfo->format.xfIndex()));
@@ -1500,13 +1503,13 @@ void WorksheetPrivate::saveXmlSheetData(QXmlStreamWriter &writer) const
 		}
 
 		//Write cell data if row contains filled cells
-        if (cellTable.contains(row_num))
+        if (ctIt != cellTable.constEnd())
         {
             for (int col_num = dimension.firstColumn(); col_num <= dimension.lastColumn(); col_num++)
             {
-                if (cellTable[row_num].contains(col_num))
+                if (ctIt->contains(col_num))
                 {
-					saveXmlCellData(writer, row_num, col_num, cellTable[row_num][col_num]);
+                    saveXmlCellData(writer, row_num, col_num, (*ctIt)[col_num]);
 				}
 			}
 		}
@@ -1524,13 +1527,16 @@ void WorksheetPrivate::saveXmlCellData(QXmlStreamWriter &writer, int row, int co
 	writer.writeStartElement(QStringLiteral("c"));
 	writer.writeAttribute(QStringLiteral("r"), cell_pos);
 
+    QMap<int, QSharedPointer<XlsxRowInfo> >::ConstIterator rIt;
+    QMap<int, QSharedPointer<XlsxColumnInfo> >::ConstIterator cIt;
+
 	//Style used by the cell, row or col
 	if (!cell->format().isEmpty())
 		writer.writeAttribute(QStringLiteral("s"), QString::number(cell->format().xfIndex()));
-	else if (rowsInfo.contains(row) && !rowsInfo[row]->format.isEmpty())
-		writer.writeAttribute(QStringLiteral("s"), QString::number(rowsInfo[row]->format.xfIndex()));
-	else if (colsInfoHelper.contains(col) && !colsInfoHelper[col]->format.isEmpty())
-		writer.writeAttribute(QStringLiteral("s"), QString::number(colsInfoHelper[col]->format.xfIndex()));
+    else if ((rIt = rowsInfo.constFind(row)) != rowsInfo.constEnd() && !(*rIt)->format.isEmpty())
+        writer.writeAttribute(QStringLiteral("s"), QString::number((*rIt)->format.xfIndex()));
+    else if ((cIt = colsInfoHelper.constFind(col)) != colsInfoHelper.constEnd() && !(*cIt)->format.isEmpty())
+        writer.writeAttribute(QStringLiteral("s"), QString::number((*cIt)->format.xfIndex()));
 
     if (cell->cellType() == Cell::SharedStringType) // 's'
     {
@@ -1910,12 +1916,13 @@ QList<int> WorksheetPrivate ::getColumnIndexes(int colFirst, int colLast)
 	nodes.append(colFirst);
     for (int col = colFirst; col <= colLast; ++col)
     {
-        if (colsInfo.contains(col))
+        auto it = colsInfo.constFind(col);
+        if (it != colsInfo.constEnd())
         {
 			if (nodes.last() != col)
 				nodes.append(col);
 
-			int nextCol = colsInfo[col]->lastColumn + 1;
+            int nextCol = (*it)->lastColumn + 1;
 			if (nextCol <= colLast)
 				nodes.append(nextCol);
 		}
@@ -2137,14 +2144,15 @@ bool Worksheet::setRowHidden(int rowFirst,int rowLast, bool hidden)
 double Worksheet::rowHeight(int row)
 {
 	Q_D(Worksheet);
-	int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
+    const int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
 
-	if (d->checkDimensions(row, min_col, false, true) || !d->rowsInfo.contains(row))
+    auto it = d->rowsInfo.constFind(row);
+    if (d->checkDimensions(row, min_col, false, true) || it == d->rowsInfo.constEnd())
     {
 		return d->sheetFormatProps.defaultRowHeight; //return default on invalid row
     }
 
-	return d->rowsInfo[row]->height;
+    return (*it)->height;
 }
 
 /*!
@@ -2153,11 +2161,12 @@ double Worksheet::rowHeight(int row)
 Format Worksheet::rowFormat(int row)
 {
 	Q_D(Worksheet);
-	int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
-	if (d->checkDimensions(row, min_col, false, true) || !d->rowsInfo.contains(row))
+    const int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
+    auto it = d->rowsInfo.constFind(row);
+    if (d->checkDimensions(row, min_col, false, true) || it == d->rowsInfo.constEnd())
 		return Format(); //return default on invalid row
 
-	return d->rowsInfo[row]->format;
+    return (*it)->format;
 }
 
 /*!
@@ -2166,11 +2175,12 @@ Format Worksheet::rowFormat(int row)
 bool Worksheet::isRowHidden(int row)
 {
 	Q_D(Worksheet);
-	int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
-	if (d->checkDimensions(row, min_col, false, true) || !d->rowsInfo.contains(row))
+    const int min_col = d->dimension.isValid() ? d->dimension.firstColumn() : 1;
+    auto it = d->rowsInfo.constFind(row);
+    if (d->checkDimensions(row, min_col, false, true) || it == d->rowsInfo.constEnd())
 		return false; //return default on invalid row
 
-	return d->rowsInfo[row]->hidden;
+    return (*it)->hidden;
 }
 
 /*!
@@ -2183,20 +2193,22 @@ bool Worksheet::groupRows(int rowFirst, int rowLast, bool collapsed)
 	Q_D(Worksheet);
 
 	for (int row=rowFirst; row<=rowLast; ++row) {
-		if (d->rowsInfo.contains(row)) {
-			d->rowsInfo[row]->outlineLevel += 1;
+        auto it = d->rowsInfo.find(row);
+        if (it != d->rowsInfo.end()) {
+            (*it)->outlineLevel += 1;
 		} else {
 			QSharedPointer<XlsxRowInfo> info(new XlsxRowInfo);
 			info->outlineLevel += 1;
-			d->rowsInfo.insert(row, info);
+            it = d->rowsInfo.insert(row, info);
 		}
 		if (collapsed)
-			d->rowsInfo[row]->hidden = true;
+            (*it)->hidden = true;
 	}
 	if (collapsed) {
-		if (!d->rowsInfo.contains(rowLast+1))
-			d->rowsInfo.insert(rowLast+1, QSharedPointer<XlsxRowInfo>(new XlsxRowInfo));
-		d->rowsInfo[rowLast+1]->collapsed = true;
+        auto it = d->rowsInfo.find(rowLast+1);
+        if (it == d->rowsInfo.end())
+            it = d->rowsInfo.insert(rowLast+1, QSharedPointer<XlsxRowInfo>(new XlsxRowInfo));
+        (*it)->collapsed = true;
 	}
 	return true;
 }
@@ -2227,10 +2239,11 @@ bool Worksheet::groupColumns(int colFirst, int colLast, bool collapsed)
 	QList<int> nodes;
 	nodes.append(colFirst);
 	for (int col = colFirst; col <= colLast; ++col) {
-		if (d->colsInfo.contains(col)) {
+        auto it = d->colsInfo.constFind(col);
+        if (it != d->colsInfo.constEnd()) {
 			if (nodes.last() != col)
 				nodes.append(col);
-			int nextCol = d->colsInfo[col]->lastColumn + 1;
+            int nextCol = (*it)->lastColumn + 1;
 			if (nextCol <= colLast)
 				nodes.append(nextCol);
 		}
@@ -2239,12 +2252,12 @@ bool Worksheet::groupColumns(int colFirst, int colLast, bool collapsed)
     for (int idx = 0; idx < nodes.size(); ++idx)
     {
 		int colStart = nodes[idx];
-        if (d->colsInfo.contains(colStart))
+        auto it = d->colsInfo.constFind(colStart);
+        if (it != d->colsInfo.constEnd())
         {
-			QSharedPointer<XlsxColumnInfo> info = d->colsInfo[colStart];
-			info->outlineLevel += 1;
+            (*it)->outlineLevel += 1;
 			if (collapsed)
-				info->hidden = true;
+                (*it)->hidden = true;
         }
         else
         {
@@ -2262,8 +2275,9 @@ bool Worksheet::groupColumns(int colFirst, int colLast, bool collapsed)
 	if (collapsed) {
 		int col = colLast+1;
 		d->splitColsInfo(col, col);
-		if (d->colsInfo.contains(col))
-			d->colsInfo[col]->collapsed = true;
+        auto it = d->colsInfo.constFind(col);
+        if (it != d->colsInfo.constEnd())
+            (*it)->collapsed = true;
 		else {
             QSharedPointer<XlsxColumnInfo> info(new XlsxColumnInfo(col, col, false));
 			info->collapsed = true;
@@ -2292,8 +2306,9 @@ CellRange Worksheet::dimension() const
 int WorksheetPrivate::rowPixelsSize(int row) const
 {
 	double height;
-	if (row_sizes.contains(row))
-		height = row_sizes[row];
+    auto it = row_sizes.constFind(row);
+    if (it != row_sizes.constEnd())
+        height = it.value();
 	else
 		height = default_row_height;
 	return static_cast<int>(4.0 / 3.0 *height);
@@ -2311,8 +2326,9 @@ int WorksheetPrivate::colPixelsSize(int col) const
 	double padding = 5.0;
 	int pixels = 0;
 
-	if (col_sizes.contains(col)) {
-		double width = col_sizes[col];
+    auto it = col_sizes.constFind(col);
+    if (it != col_sizes.constEnd()) {
+        double width = it.value();
 		if (width < 1)
 			pixels = static_cast<int>(width * (max_digit_width + padding) + 0.5);
 		else
@@ -2788,10 +2804,10 @@ QList <QSharedPointer<XlsxColumnInfo> > WorksheetPrivate::getColumnInfoList(int 
         for (int idx = 0; idx < nodes.size(); ++idx)
         {
 			int colStart = nodes[idx];
-            if (colsInfo.contains(colStart))
+            auto it = colsInfo.constFind(colStart);
+            if (it != colsInfo.constEnd())
             {
-				QSharedPointer<XlsxColumnInfo> info = colsInfo[colStart];
-				columnsInfoList.append(info);
+                columnsInfoList.append(*it);
             }
             else
             {

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -115,7 +115,7 @@ void WorksheetPrivate::calculateSpans() const
 
 		if (row_num%16 == 0 || row_num == dimension.lastRow()) {
 			if (span_max != -1) {
-				row_spans[row_num / 16] = QString("%1:%2").arg(span_min).arg(span_max);
+                row_spans[row_num / 16] = QStringLiteral("%1:%2").arg(span_min).arg(span_max);
 				span_min = XLSX_COLUMN_MAX+1;
 				span_max = -1;
 			}
@@ -1326,7 +1326,7 @@ void Worksheet::saveToXmlFile(QIODevice *device) const
 	writer.writeEndElement();//sheetData
 
 	d->saveXmlMergeCells(writer);
-	foreach (const ConditionalFormatting cf, d->conditionalFormattingList)
+    for (const ConditionalFormatting &cf : d->conditionalFormattingList)
 		cf.saveToXml(writer);
 	d->saveXmlDataValidations(writer);
 
@@ -1751,7 +1751,7 @@ void WorksheetPrivate::saveXmlMergeCells(QXmlStreamWriter &writer) const
 	writer.writeStartElement(QStringLiteral("mergeCells"));
 	writer.writeAttribute(QStringLiteral("count"), QString::number(merges.size()));
 
-    foreach (CellRange range, merges)
+    for (const CellRange &range : merges)
     {
 		writer.writeEmptyElement(QStringLiteral("mergeCell"));
 		writer.writeAttribute(QStringLiteral("ref"), range.toString());
@@ -1768,7 +1768,7 @@ void WorksheetPrivate::saveXmlDataValidations(QXmlStreamWriter &writer) const
 	writer.writeStartElement(QStringLiteral("dataValidations"));
 	writer.writeAttribute(QStringLiteral("count"), QString::number(dataValidationsList.size()));
 
-	foreach (DataValidation validation, dataValidationsList)
+    for (const DataValidation &validation : dataValidationsList)
 		validation.saveToXml(writer);
 
 	writer.writeEndElement(); //dataValidations
@@ -1806,7 +1806,7 @@ void WorksheetPrivate::saveXmlHyperlinks(QXmlStreamWriter &writer) const
                 // Update relationships
 				relationships->addWorksheetRelationship(QStringLiteral("/hyperlink"), data->target, QStringLiteral("External"));
 
-				writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
+                writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
 			}
 
 			if (!data->location.isEmpty())
@@ -1838,10 +1838,10 @@ void WorksheetPrivate::saveXmlDrawings(QXmlStreamWriter &writer) const
 		return;
 
 	int idx = workbook->drawings().indexOf(drawing.data());
-	relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QString("../drawings/drawing%1.xml").arg(idx+1));
+    relationships->addWorksheetRelationship(QStringLiteral("/drawing"), QStringLiteral("../drawings/drawing%1.xml").arg(idx+1));
 
 	writer.writeEmptyElement(QStringLiteral("drawing"));
-	writer.writeAttribute(QStringLiteral("r:id"), QString("rId%1").arg(relationships->count()));
+    writer.writeAttribute(QStringLiteral("r:id"), QStringLiteral("rId%1").arg(relationships->count()));
 }
 
 void WorksheetPrivate::splitColsInfo(int colFirst, int colLast)
@@ -1970,8 +1970,8 @@ bool Worksheet::setColumnWidth(int colFirst, int colLast, double width)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
     {
 	   columnInfo->width = width;
     }
@@ -1988,8 +1988,8 @@ bool Worksheet::setColumnFormat(int colFirst, int colLast, const Format &format)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
 	   columnInfo->format = format;
 
 	if(columnInfoList.count() > 0) {
@@ -2008,8 +2008,8 @@ bool Worksheet::setColumnHidden(int colFirst, int colLast, bool hidden)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
-	foreach(QSharedPointer<XlsxColumnInfo>  columnInfo, columnInfoList)
+    const QList <QSharedPointer<XlsxColumnInfo> > columnInfoList = d->getColumnInfoList(colFirst, colLast);
+    for (const QSharedPointer<XlsxColumnInfo> &columnInfo : columnInfoList)
 	   columnInfo->hidden = hidden;
 
 	return (columnInfoList.count() > 0);
@@ -2087,9 +2087,8 @@ bool Worksheet::setRowHeight(int rowFirst,int rowLast, double height)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList) {
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList) {
 		rowInfo->height = height;
 		rowInfo->customHeight = true;
 	}
@@ -2107,9 +2106,8 @@ bool Worksheet::setRowFormat(int rowFirst,int rowLast, const Format &format)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList)
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList)
 		rowInfo->format = format;
 
 	d->workbook->styles()->addXfFormat(format);
@@ -2126,8 +2124,8 @@ bool Worksheet::setRowHidden(int rowFirst,int rowLast, bool hidden)
 {
 	Q_D(Worksheet);
 
-	QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
-	foreach(QSharedPointer<XlsxRowInfo> rowInfo, rowInfoList)
+    const QList <QSharedPointer<XlsxRowInfo> > rowInfoList = d->getRowInfoList(rowFirst,rowLast);
+    for (const QSharedPointer<XlsxRowInfo> &rowInfo : rowInfoList)
 		rowInfo->hidden = hidden;
 
 	return rowInfoList.count() > 0;
@@ -2687,7 +2685,7 @@ void WorksheetPrivate::loadXmlSheetFormatProps(QXmlStreamReader &reader)
     bool isSetWidth = false;
 
     // Retain default values
-    foreach (QXmlStreamAttribute attrib, attributes)
+    for  (const QXmlStreamAttribute &attrib : attributes)
     {
         if(attrib.name() == QLatin1String("baseColWidth") )
         {
@@ -2957,16 +2955,18 @@ void WorksheetPrivate::validateDimension()
 	int firstColumn = -1;
 	int lastColumn = -1;
 
-	for (QMap<int, QMap<int, QSharedPointer<Cell> > >::const_iterator it = cellTable.begin(); it != cellTable.end(); ++it)
-	{
-		Q_ASSERT(!it.value().isEmpty());
+    auto it = cellTable.constBegin();
+    while (it != cellTable.constEnd()) {
+        Q_ASSERT(!it.value().isEmpty());
 
-		if (firstColumn == -1 || it.value().constBegin().key() < firstColumn)
-			firstColumn = it.value().constBegin().key();
+        if (firstColumn == -1 || it.value().constBegin().key() < firstColumn)
+            firstColumn = it.value().constBegin().key();
 
-		if (lastColumn == -1 || (it.value().constEnd()-1).key() > lastColumn)
-			lastColumn = (it.value().constEnd()-1).key();
-	}
+        if (lastColumn == -1 || (it.value().constEnd()-1).key() > lastColumn)
+            lastColumn = (it.value().constEnd()-1).key();
+
+        ++it;
+    }
 
 	CellRange cr(firstRow, firstColumn, lastRow, lastColumn);
 

--- a/QXlsx/source/xlsxzipreader.cpp
+++ b/QXlsx/source/xlsxzipreader.cpp
@@ -49,11 +49,11 @@ ZipReader::~ZipReader()
 void ZipReader::init()
 {
 #if QT_VERSION >= 0x050600 // Qt 5.6 or over 
-    QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    const QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
 #else
-    QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
+    const QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
 #endif
-    foreach (const QZipReader::FileInfo &fi, allFiles) {
+    for (const QZipReader::FileInfo &fi : allFiles) {
         if (fi.isFile || (!fi.isDir && !fi.isFile && !fi.isSymLink))
             m_filePaths.append(fi.filePath);
     }


### PR DESCRIPTION
Using contains(foo) && .value(foo) results
in two lookups on the containers using
iterators with find() and it.value() is more efficient