### PR TITLE
Allow library to be used with add_subdirectory() in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,18 +28,18 @@ add_library(QXlsx)
 # Target
 #------------------------------------------------------------------------------
 # Define target sources
-file(GLOB_RECURSE files ${CMAKE_SOURCE_DIR}/QXlsx/source/*.cpp ${CMAKE_SOURCE_DIR}/QXlsx/header/*.h)
+file(GLOB_RECURSE files ${PROJECT_SOURCE_DIR}/QXlsx/source/*.cpp ${PROJECT_SOURCE_DIR}/QXlsx/header/*.h)
 
 target_sources(QXlsx PRIVATE
   ${files}
 )
 
 target_link_libraries(QXlsx PUBLIC Qt5::Core Qt5::Gui Qt5::GuiPrivate)
-target_include_directories(QXlsx PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/QXlsx/header)
+target_include_directories(QXlsx PUBLIC ${PROJECT_SOURCE_DIR}/QXlsx/header)
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/CMake/QXlsxConfig.cmake.in
-  "${CMAKE_BINARY_DIR}/QXlsxConfig.cmake" @ONLY)
+  ${PROJECT_SOURCE_DIR}/CMake/QXlsxConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/QXlsxConfig.cmake" @ONLY)
 
 export(TARGETS QXlsx
-  FILE "${CMAKE_BINARY_DIR}/QXlsxTargets.cmake")
+  FILE "${PROJECT_BINARY_DIR}/QXlsxTargets.cmake")


### PR DESCRIPTION
Use `${PROJECT_*_DIR}`, which is relative to the current `project()` instead
of `${CMAKE_*_DIR}` which is relative to the top-level CMakeLists.txt

This allows you to use the QXlsx library in another cmake based project as follows:

    your_project/
        third-party/QXlsx/
        CMakeLists.txt
        ...

CMakeLists.txt:

```
add_subdirectory("third-party/QXlsx")
target_link_libraries(${PROJECT_NAME}
        ....
        QXlsx
)

target_include_directories(${PROJECT_NAME}
    PRIVATE
        ...
        QXlsx
)
```