### PR TITLE
QT 6 refactor - prefer const auto& reference to macros and hard coded types

### DIFF
--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -516,11 +516,7 @@ bool ChartPrivate::loadXmlPlotAreaElement(QXmlStreamReader &reader)
 
 bool ChartPrivate::loadXmlXxxChart(QXmlStreamReader &reader)
 {
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-    QStringView name = reader.name();
-#else
-    QStringRef name = reader.name();
-#endif
+    const auto& name = reader.name();
 
     if (name == QLatin1String("areaChart"))
     {
@@ -650,13 +646,7 @@ bool ChartPrivate::loadXmlSer(QXmlStreamReader &reader)
         if (reader.readNextStartElement())
         {
             //TODO beide Header noch auswerten RTR 2019.11
-
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-            QStringView name = reader.name();
-#else
-            QStringRef name = reader.name();
-#endif
-
+            const auto& name = reader.name();
             if ( name == QLatin1String("tx") )
             {
                 while ( !reader.atEnd() &&
@@ -2249,12 +2239,7 @@ QString ChartPrivate::readSubTree(QXmlStreamReader &reader)
 {
     QString treeString;
     QString prefix;
-
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-    QStringView treeName = reader.name();
-#else
-    QStringRef treeName = reader.name();
-#endif
+    const auto& treeName = reader.name();
 
     while (!reader.atEnd())
     {

--- a/QXlsx/source/xlsxcolor.cpp
+++ b/QXlsx/source/xlsxcolor.cpp
@@ -1,6 +1,5 @@
 // xlsxcolor.cpp
 
-#include <QtGlobal>
 #include <QDataStream>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
@@ -32,9 +31,7 @@ XlsxColor::XlsxColor(int index)
 
 bool XlsxColor::isRgbColor() const
 {
-    if (val.userType() == qMetaTypeId<QColor>() && val.value<QColor>().isValid())
-        return true;
-    return false;
+    return val.userType() == qMetaTypeId<QColor>() && val.value<QColor>().isValid();
 }
 
 bool XlsxColor::isIndexedColor() const
@@ -54,23 +51,17 @@ bool XlsxColor::isInvalid() const
 
 QColor XlsxColor::rgbColor() const
 {
-    if (isRgbColor())
-        return val.value<QColor>();
-    return QColor();
+    return isRgbColor() ? val.value<QColor>() : QColor();
 }
 
 int XlsxColor::indexedColor() const
 {
-    if (isIndexedColor())
-        return val.toInt();
-    return -1;
+    return isIndexedColor() ? val.toInt() : -1;
 }
 
 QStringList XlsxColor::themeColor() const
 {
-    if (isThemeColor())
-        return val.toStringList();
-    return QStringList();
+    return isThemeColor() ? val.toStringList() : QStringList();
 }
 
 bool XlsxColor::saveToXml(QXmlStreamWriter &writer, const QString &node) const
@@ -98,17 +89,17 @@ bool XlsxColor::saveToXml(QXmlStreamWriter &writer, const QString &node) const
 
 bool XlsxColor::loadFromXml(QXmlStreamReader &reader)
 {
-    QXmlStreamAttributes attributes = reader.attributes();
+    const auto& attributes = reader.attributes();
 
     if (attributes.hasAttribute(QLatin1String("rgb"))) {
-        QString colorString = attributes.value(QLatin1String("rgb")).toString();
+        const auto& colorString = attributes.value(QLatin1String("rgb")).toString();
         val.setValue(fromARGBString(colorString));
     } else if (attributes.hasAttribute(QLatin1String("indexed"))) {
         int index = attributes.value(QLatin1String("indexed")).toString().toInt();
         val.setValue(index);
     } else if (attributes.hasAttribute(QLatin1String("theme"))) {
-        QString theme = attributes.value(QLatin1String("theme")).toString();
-        QString tint = attributes.value(QLatin1String("tint")).toString();
+        const auto& theme = attributes.value(QLatin1String("theme")).toString();
+        const auto& tint = attributes.value(QLatin1String("tint")).toString();
         val.setValue(QStringList()<<theme<<tint);
     }
     return true;
@@ -116,11 +107,13 @@ bool XlsxColor::loadFromXml(QXmlStreamReader &reader)
 
 XlsxColor::operator QVariant() const
 {
+    const auto& cref
 #if QT_VERSION >= 0x060000 // Qt 6.0 or over
-    return QVariant((QMetaType) qMetaTypeId<XlsxColor>(), this);
+        = QMetaType::fromType<XlsxColor>();
 #else
-    return QVariant(qMetaTypeId<XlsxColor>(), this);
+        = qMetaTypeId<XlsxColor>() ;
 #endif
+    return QVariant(cref, this);
 }
 
 
@@ -146,15 +139,13 @@ QColor XlsxColor::fromARGBString(const QString &c)
 
 QString XlsxColor::toARGBString(const QColor &c)
 {
-    QString color;
-
 #if QT_VERSION >= 0x050600 // Qt 5.6 or over
-    color = QString::asprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
+    return QString::asprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
 #else
+    QString color;
     color.sprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
-#endif
-
     return color;
+#endif
 }
 
 #if !defined(QT_NO_DATASTREAM)

--- a/QXlsx/source/xlsxdocpropscore.cpp
+++ b/QXlsx/source/xlsxdocpropscore.cpp
@@ -128,13 +128,8 @@ bool DocPropsCore::loadFromXmlFile(QIODevice *device)
          if (token == QXmlStreamReader::StartElement)
          {
 
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-             const QStringView nsUri = reader.namespaceUri();
-             const QStringView name = reader.name();
-#else
-             const QStringRef nsUri = reader.namespaceUri();
-             const QStringRef name = reader.name();
-#endif
+             const auto& nsUri = reader.namespaceUri();
+             const auto& name = reader.name();
 
              if (name == QStringLiteral("subject") && nsUri == dc)
              {

--- a/QXlsx/source/xlsxrichstring.cpp
+++ b/QXlsx/source/xlsxrichstring.cpp
@@ -84,11 +84,13 @@ RichString &RichString::operator =(const RichString &other)
 */
 RichString::operator QVariant() const
 {
-#if QT_VERSION >= 0x060000 // ver 6.0
-    return QVariant((QMetaType) qMetaTypeId<RichString>(), this);
+    const auto& cref
+#if QT_VERSION >= 0x060000 // Qt 6.0 or over
+        = QMetaType::fromType<RichString>();
 #else
-    return QVariant(qMetaTypeId<RichString>(), this);
+        = qMetaTypeId<RichString>() ;
 #endif
+    return QVariant(cref, this);
 }
 
 /*!

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -149,12 +149,12 @@ void Styles::fixNumFmt(const Format &format)
 
     }
 
-    const QString str = format.numberFormat();
+    const auto& str = format.numberFormat();
     if (!str.isEmpty())
     {
         QHash<QString, QSharedPointer<XlsxFormatNumberData> >::ConstIterator cIt;
         //Assign proper number format index
-        auto it = m_builtinNumFmtsHash.constFind(str);
+        const auto& it = m_builtinNumFmtsHash.constFind(str);
         if (it != m_builtinNumFmtsHash.constEnd())
         {
             const_cast<Format *>(&format)->fixNumberFormat(it.value(), str);
@@ -179,9 +179,9 @@ void Styles::fixNumFmt(const Format &format)
     }
     else
     {
-        int id = format.numberFormatIndex();
+        const auto id = format.numberFormatIndex();
         //Assign proper format code, this is needed by dxf format
-        auto it = m_customNumFmtIdMap.constFind(id);
+        const auto& it = m_customNumFmtIdMap.constFind(id);
         if (it != m_customNumFmtIdMap.constEnd())
         {
             const_cast<Format *>(&format)->fixNumberFormat(id, it.value()->formatString);
@@ -189,8 +189,7 @@ void Styles::fixNumFmt(const Format &format)
         else
         {
             bool found = false;
-            auto it = m_builtinNumFmtsHash.constBegin();
-            while (it != m_builtinNumFmtsHash.constEnd())
+            for ( auto&& it = m_builtinNumFmtsHash.constBegin() ; it != m_builtinNumFmtsHash.constEnd() ; ++it )
             {
                 if (it.value() == id)
                 {
@@ -198,7 +197,6 @@ void Styles::fixNumFmt(const Format &format)
                     found = true;
                     break;
                 }
-                ++it;
             }
 
             if (!found)
@@ -236,7 +234,7 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Font
-    auto fontIt = m_fontsHash.constFind(format.fontKey());
+    const auto& fontIt = m_fontsHash.constFind(format.fontKey());
     if (format.hasFontData() && !format.fontIndexValid())
     {
         //Assign proper font index, if has font data.
@@ -253,7 +251,7 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Fill
-    auto fillIt = m_fillsHash.constFind(format.fillKey());
+    const auto& fillIt = m_fillsHash.constFind(format.fillKey());
     if (format.hasFillData() && !format.fillIndexValid()) {
         //Assign proper fill index, if has fill data.
         if (fillIt == m_fillsHash.constEnd())
@@ -268,7 +266,7 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Border
-    auto borderIt = m_bordersHash.constFind(format.borderKey());
+    const auto& borderIt = m_bordersHash.constFind(format.borderKey());
     if (format.hasBorderData() && !format.borderIndexValid()) {
         //Assign proper border index, if has border data.
         if (borderIt == m_bordersHash.constEnd())
@@ -283,7 +281,7 @@ void Styles::addXfFormat(const Format &format, bool force)
     }
 
     //Format
-    auto formatIt = m_xf_formatsHash.constFind(format.formatKey());
+    const auto& formatIt = m_xf_formatsHash.constFind(format.formatKey());
     if (!format.isEmpty() && !format.xfIndexValid())
     {
         if (formatIt == m_xf_formatsHash.constEnd())
@@ -308,7 +306,7 @@ void Styles::addDxfFormat(const Format &format, bool force)
         fixNumFmt(format);
     }
 
-    auto formatIt = m_dxf_formatsHash.constFind(format.formatKey());
+    const auto& formatIt = m_dxf_formatsHash.constFind(format.formatKey());
     if ( !format.isEmpty() &&
             !format.dxfIndexValid() )
     {
@@ -402,7 +400,7 @@ void Styles::writeFonts(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("fonts"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_fontsList.count()));
-    for (int i=0; i<m_fontsList.size(); ++i)
+    for (size_t i=0; i<m_fontsList.size(); ++i)
         writeFont(writer, m_fontsList[i], false);
     writer.writeEndElement();//fonts
 }
@@ -493,7 +491,7 @@ void Styles::writeFills(QXmlStreamWriter &writer) const
     writer.writeStartElement(QStringLiteral("fills"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_fillsList.size()));
 
-    for (int i=0; i<m_fillsList.size(); ++i)
+    for (size_t i=0; i<m_fillsList.size(); ++i)
         writeFill(writer, m_fillsList[i]);
 
     writer.writeEndElement(); //fills
@@ -551,7 +549,7 @@ void Styles::writeBorders(QXmlStreamWriter &writer) const
 {
     writer.writeStartElement(QStringLiteral("borders"));
     writer.writeAttribute(QStringLiteral("count"), QString::number(m_bordersList.count()));
-    for (int i=0; i<m_bordersList.size(); ++i)
+    for (size_t i=0; i<m_bordersList.size(); ++i)
         writeBorder(writer, m_bordersList[i]);
     writer.writeEndElement();//borders
 }
@@ -757,9 +755,9 @@ void Styles::writeColors(QXmlStreamWriter &writer) const
 bool Styles::readNumFmts(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("numFmts"));
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
 
     //Read utill we find the numFmts end tag or ....
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
@@ -767,7 +765,7 @@ bool Styles::readNumFmts(QXmlStreamReader &reader)
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("numFmt")) {
-                QXmlStreamAttributes attributes = reader.attributes();
+                const auto& attributes = reader.attributes();
                 QSharedPointer<XlsxFormatNumberData> fmt (new XlsxFormatNumberData);
                 fmt->formatIndex = attributes.value(QLatin1String("numFmtId")).toString().toInt();
                 fmt->formatString = attributes.value(QLatin1String("formatCode")).toString();
@@ -791,9 +789,9 @@ bool Styles::readNumFmts(QXmlStreamReader &reader)
 bool Styles::readFonts(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("fonts"));
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("fonts"))) {
         reader.readNextStartElement();
@@ -823,7 +821,7 @@ bool Styles::readFont(QXmlStreamReader &reader, Format &format)
                                && reader.name() == QLatin1String("font"))) {
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
-            QXmlStreamAttributes attributes = reader.attributes();
+            const auto& attributes = reader.attributes();
             if (reader.name() == QLatin1String("name")) {
                 format.setFontName(attributes.value(QLatin1String("val")).toString());
             } else if (reader.name() == QLatin1String("charset")) {
@@ -849,7 +847,7 @@ bool Styles::readFont(QXmlStreamReader &reader, Format &format)
                 color.loadFromXml(reader);
                 format.setProperty(FormatPrivate::P_Font_Color, color);
             } else if (reader.name() == QLatin1String("sz")) {
-                int sz = attributes.value(QLatin1String("val")).toString().toInt();
+                const auto sz = attributes.value(QLatin1String("val")).toString().toInt();
                 format.setFontSize(sz);
             } else if (reader.name() == QLatin1String("u")) {
                 QString value = attributes.value(QLatin1String("val")).toString();
@@ -879,9 +877,9 @@ bool Styles::readFills(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("fills"));
 
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("fills"))) {
         reader.readNextStartElement();
@@ -934,9 +932,9 @@ bool Styles::readFill(QXmlStreamReader &reader, Format &fill)
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("patternFill")) {
-                QXmlStreamAttributes attributes = reader.attributes();
+                const auto& attributes = reader.attributes();
                 if (attributes.hasAttribute(QLatin1String("patternType"))) {
-                    auto it = patternValues.constFind(attributes.value(QLatin1String("patternType")).toString());
+                    const auto& it = patternValues.constFind(attributes.value(QLatin1String("patternType")).toString());
                     fill.setFillPattern(it != patternValues.constEnd() ? it.value() : Format::PatternNone);
 
                     //parse foreground and background colors if they exist
@@ -976,9 +974,9 @@ bool Styles::readBorders(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("borders"));
 
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("borders"))) {
         reader.readNextStartElement();
@@ -1007,9 +1005,9 @@ bool Styles::readBorder(QXmlStreamReader &reader, Format &border)
 {
     Q_ASSERT(reader.name() == QLatin1String("border"));
 
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool isUp = attributes.hasAttribute(QLatin1String("diagonalUp"));
-    bool isDown = attributes.hasAttribute(QLatin1String("diagonalUp"));
+    const auto& attributes = reader.attributes();
+    const auto isUp = attributes.hasAttribute(QLatin1String("diagonalUp"));
+    const auto isDown = attributes.hasAttribute(QLatin1String("diagonalUp"));
     if (isUp && isDown)
         border.setDiagonalBorderType(Format::DiagnoalBorderBoth);
     else if (isUp)
@@ -1085,10 +1083,10 @@ bool Styles::readSubBorder(QXmlStreamReader &reader, const QString &name, Format
         {QStringLiteral("slantDashDot"), Format::BorderSlantDashDot}
     };
 
-    QXmlStreamAttributes attributes = reader.attributes();
+    const auto& attributes = reader.attributes();
     if (attributes.hasAttribute(QLatin1String("style"))) {
         QString styleString = attributes.value(QLatin1String("style")).toString();
-        auto it = stylesStringsMap.constFind(styleString);
+        const auto& it = stylesStringsMap.constFind(styleString);
         if (it != stylesStringsMap.constEnd()) {
             //get style
             style = it.value();
@@ -1108,9 +1106,9 @@ bool Styles::readSubBorder(QXmlStreamReader &reader, const QString &name, Format
 bool Styles::readCellXfs(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("cellXfs"));
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                 && reader.name() == QLatin1String("cellXfs"))) {
         reader.readNextStartElement();
@@ -1118,17 +1116,17 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("xf")) {
 
                 Format format;
-                QXmlStreamAttributes xfAttrs = reader.attributes();
+                const auto& xfAttrs = reader.attributes();
 
                 //        qDebug()<<reader.name()<<reader.tokenString()<<" .........";
                 //        for (int i=0; i<xfAttrs.size(); ++i)
                 //            qDebug()<<"... "<<i<<" "<<xfAttrs[i].name()<<xfAttrs[i].value();
 
                 if (xfAttrs.hasAttribute(QLatin1String("numFmtId"))) {
-                    int numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toString().toInt();
-                    bool apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyNumberFormat")).toString());
+                    const auto numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toString().toInt();
+                    const auto apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyNumberFormat")).toString());
                     if(apply) {
-                        auto it = m_customNumFmtIdMap.constFind(numFmtIndex);
+                        const auto& it = m_customNumFmtIdMap.constFind(numFmtIndex);
                         if (it == m_customNumFmtIdMap.constEnd())
                             format.setNumberFormatIndex(numFmtIndex);
                         else
@@ -1137,11 +1135,11 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("fontId"))) {
-                    int fontIndex = xfAttrs.value(QLatin1String("fontId")).toString().toInt();
+                    const auto fontIndex = xfAttrs.value(QLatin1String("fontId")).toString().toInt();
                     if (fontIndex >= m_fontsList.size()) {
                         qDebug("Error read styles.xml, cellXfs fontId");
                     } else {
-                        bool apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyFont")).toString());
+                        const auto apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyFont")).toString());
                         if(apply) {
                             Format fontFormat = m_fontsList[fontIndex];
                             for (int i=FormatPrivate::P_Font_STARTID; i<FormatPrivate::P_Font_ENDID; ++i) {
@@ -1153,7 +1151,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("fillId"))) {
-                    int id = xfAttrs.value(QLatin1String("fillId")).toString().toInt();
+                    const auto id = xfAttrs.value(QLatin1String("fillId")).toString().toInt();
                     if (id >= m_fillsList.size()) {
                         qDebug("Error read styles.xml, cellXfs fillId");
                     } else {
@@ -1178,11 +1176,11 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("borderId"))) {
-                    int id = xfAttrs.value(QLatin1String("borderId")).toString().toInt();
+                    const auto id = xfAttrs.value(QLatin1String("borderId")).toString().toInt();
                     if (id >= m_bordersList.size()) {
                         qDebug("Error read styles.xml, cellXfs borderId");
                     } else {
-                        bool apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyBorder")).toString());
+                        const auto apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyBorder")).toString());
                         if(apply) {
                             Format borderFormat = m_bordersList[id];
                             for (int i=FormatPrivate::P_Border_STARTID; i<FormatPrivate::P_Border_ENDID; ++i) {
@@ -1193,11 +1191,11 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                     }
                 }
 
-                bool apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyAlignment")).toString());
+                const auto apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyAlignment")).toString());
                 if(apply) {
                     reader.readNextStartElement();
                     if (reader.name() == QLatin1String("alignment")) {
-                        QXmlStreamAttributes alignAttrs = reader.attributes();
+                        const auto& alignAttrs = reader.attributes();
 
                         if (alignAttrs.hasAttribute(QLatin1String("horizontal"))) {
                             static const QMap<QString, Format::HorizontalAlignment> alignStringMap = {
@@ -1209,7 +1207,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                                 {QStringLiteral("distributed"), Format::AlignHDistributed}
                             };
 
-                            auto it = alignStringMap.constFind(alignAttrs.value(QLatin1String("horizontal")).toString());
+                            const auto& it = alignStringMap.constFind(alignAttrs.value(QLatin1String("horizontal")).toString());
                             if (it != alignStringMap.constEnd())
                                 format.setHorizontalAlignment(it.value());
                         }
@@ -1222,18 +1220,18 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                                 {QStringLiteral("distributed"), Format::AlignVDistributed}
                             };
 
-                            auto it = alignStringMap.constFind(alignAttrs.value(QLatin1String("vertical")).toString());
+                            const auto& it = alignStringMap.constFind(alignAttrs.value(QLatin1String("vertical")).toString());
                             if (it != alignStringMap.constEnd())
                                 format.setVerticalAlignment(it.value());
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("indent"))) {
-                            int indent = alignAttrs.value(QLatin1String("indent")).toString().toInt();
+                            const auto indent = alignAttrs.value(QLatin1String("indent")).toString().toInt();
                             format.setIndent(indent);
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("textRotation"))) {
-                            int rotation = alignAttrs.value(QLatin1String("textRotation")).toString().toInt();
+                            const auto rotation = alignAttrs.value(QLatin1String("textRotation")).toString().toInt();
                             format.setRotation(rotation);
                         }
 
@@ -1263,9 +1261,9 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
 bool Styles::readDxfs(QXmlStreamReader &reader)
 {
     Q_ASSERT(reader.name() == QLatin1String("dxfs"));
-    QXmlStreamAttributes attributes = reader.attributes();
-    bool hasCount = attributes.hasAttribute(QLatin1String("count"));
-    int count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto& attributes = reader.attributes();
+    const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                 && reader.name() == QLatin1String("dxfs"))) {
         reader.readNextStartElement();
@@ -1291,8 +1289,8 @@ bool Styles::readDxf(QXmlStreamReader &reader)
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("numFmt")) {
-                QXmlStreamAttributes attributes = reader.attributes();
-                int id = attributes.value(QLatin1String("numFmtId")).toString().toInt();
+                const auto& attributes = reader.attributes();
+                const auto id = attributes.value(QLatin1String("numFmtId")).toString().toInt();
                 QString code = attributes.value(QLatin1String("formatCode")).toString();
                 format.setNumberFormat(id, code);
             } else if (reader.name() == QLatin1String("font")) {
@@ -1332,7 +1330,7 @@ bool Styles::readIndexedColors(QXmlStreamReader &reader)
         reader.readNextStartElement();
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("rgbColor")) {
-                QString color = reader.attributes().value(QLatin1String("rgb")).toString();
+                const auto& color = reader.attributes().value(QLatin1String("rgb")).toString();
                 m_indexedColors.append(XlsxColor::fromARGBString(color));
             }
         }

--- a/QXlsx/source/xlsxutility.cpp
+++ b/QXlsx/source/xlsxutility.cpp
@@ -246,7 +246,7 @@ QString convertSharedFormula(const QString &rootFormula, const CellReference &ro
                     refState = PRE_09;
                     refFlag |= 0x02;
                 } else {
-                    segments.append({ segment, refState==_09 ? refFlag : -1 });
+                    segments.append(std::make_pair(segment, refState==_09 ? refFlag : -1 ));
                     segment = QString(ch); //Start new segment.
                     refState = PRE_AZ;
                     refFlag = 0x01;
@@ -255,7 +255,7 @@ QString convertSharedFormula(const QString &rootFormula, const CellReference &ro
                 if (refState == PRE_AZ || refState == AZ) {
                     segment.append(ch);
                 } else {
-                    segments.append({ segment, refState==_09 ? refFlag : -1 });
+                    segments.append(std::make_pair(segment, refState==_09 ? refFlag : -1 ));
                     segment = QString(ch); //Start new segment.
                     refFlag = 0x00;
                 }
@@ -269,7 +269,7 @@ QString convertSharedFormula(const QString &rootFormula, const CellReference &ro
                     refState = INVALID;
             } else {
                 if (refState == _09) {
-                    segments.append({ segment, refFlag });
+                    segments.append(std::make_pair(segment, refFlag ));
                     segment = QString(ch); //Start new segment.
                 } else {
                     segment.append(ch);
@@ -280,7 +280,7 @@ QString convertSharedFormula(const QString &rootFormula, const CellReference &ro
     }
 
     if (!segment.isEmpty())
-        segments.append({ segment, refState==_09 ? refFlag : -1 });
+        segments.append(std::make_pair(segment, refState==_09 ? refFlag : -1 ));
 
     //Replace "A1", "$A1", "A$1" segment with proper one.
     QStringList result;

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -569,17 +569,13 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
              {
                  QXmlStreamAttributes attributes = reader.attributes();
 
-                 const QString name = attributes.value(QLatin1String("name")).toString();
+                 const auto& name = attributes.value(QLatin1String("name")).toString();
 
                  int sheetId = attributes.value(QLatin1String("sheetId")).toString().toInt();
 
-                 const QString rId = attributes.value(QLatin1String("r:id")).toString();
+                 const auto& rId = attributes.value(QLatin1String("r:id")).toString();
 
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-                 const QStringView &stateString = attributes.value(QLatin1String("state"));
-#else
-                 const QStringRef &stateString = attributes.value(QLatin1String("state"));
-#endif
+                 const auto& stateString = attributes.value(QLatin1String("state"));
 
                  AbstractSheet::SheetState state = AbstractSheet::SS_Visible;
                  if (stateString == QLatin1String("hidden"))

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2939,39 +2939,27 @@ void WorksheetPrivate::validateDimension()
 	if (dimension.isValid() || cellTable.isEmpty())
 		return;
 
-	int firstRow = cellTable.constBegin().key();
+	const auto firstRow = cellTable.constBegin().key();
 
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-        int lastRow = (cellTable.constEnd()--).key();
-#else
-    int lastRow = (cellTable.constEnd()-1).key();
-#endif
+    const auto lastRow = (--cellTable.constEnd()).key();
 
 	int firstColumn = -1;
 	int lastColumn = -1;
 
-    auto it = cellTable.constBegin();
-    while (it != cellTable.constEnd())
+    for ( auto&& it = cellTable.constBegin()
+            ; it != cellTable.constEnd()
+            ; ++it )
     {
         Q_ASSERT(!it.value().isEmpty());
 
         if (firstColumn == -1 || it.value().constBegin().key() < firstColumn)
             firstColumn = it.value().constBegin().key();
 
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-        if (lastColumn == -1 || (it.value().constEnd()--).key() > lastColumn)
-#else
-        if (lastColumn == -1 || (it.value().constEnd()-1).key() > lastColumn)
-#endif
+        if (lastColumn == -1 || (--it.value().constEnd()).key() > lastColumn)
         {
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-            lastColumn = (it.value().constEnd()--).key();
-#else
-            lastColumn = (it.value().constEnd()-1).key();
-#endif
+            lastColumn = (--it.value().constEnd()).key();
         }
 
-        ++it;
     }
 
 	CellRange cr(firstRow, firstColumn, lastRow, lastColumn);

--- a/QXlsx/source/xlsxzipreader.cpp
+++ b/QXlsx/source/xlsxzipreader.cpp
@@ -25,12 +25,8 @@ ZipReader::~ZipReader()
 
 void ZipReader::init()
 {
-#if QT_VERSION >= 0x050600 // Qt 5.6 or over 
-    const QVector<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
-#else
-    const QList<QZipReader::FileInfo> allFiles = m_reader->fileInfoList();
-#endif
-    for (const QZipReader::FileInfo &fi : allFiles) {
+    const auto& allFiles = m_reader->fileInfoList();
+    for (const auto &fi : allFiles) {
         if (fi.isFile || (!fi.isDir && !fi.isFile && !fi.isSymLink))
             m_filePaths.append(fi.filePath);
     }


### PR DESCRIPTION

- eliminates QT_VERSION macros used to hardcode QString or QStringRef
- assures lvalue
   - enables compiler optimization
   - assures maintainer rvalue unneeded
- insures no temporaries
   - make an rvalue instance
   - then make an lvalue instance
   - then op=(rhs)
- auto keyword is C++11 and used elsewhere in codebase