### PR TITLE
support shared and static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 
 project(QXlsx VERSION 1.3.56 LANGUAGES CXX)
 
+option(BUILD_SHARED_LIB "Build shared library (DLL)." ON)
+
 include(GNUInstallDirs)
 
 find_package(Qt5 CONFIG REQUIRED COMPONENTS Gui)
@@ -10,7 +12,16 @@ set(CMAKE_AUTOMOC ON)
 #------------------------------------------------------------------------------
 # Library
 #------------------------------------------------------------------------------
-add_library(QXlsx)
+if (BUILD_SHARED_LIB)
+    add_library(QXlsx SHARED)
+    set_target_properties(QXlsx PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    if (UNIX)
+        # force linker to resolve all deps
+        set_target_properties(QXlsx PROPERTIES LINK_FLAGS "-Wl,--no-undefined")
+    endif (UNIX)
+else (BUILD_SHARED_LIB)
+    add_library(QXlsx)
+endif (BUILD_SHARED_LIB)
 set_target_properties(QXlsx PROPERTIES
 	SOVERSION ${PROJECT_VERSION})
 


### PR DESCRIPTION
We use QXSLX as dlls on windows and *.so on Debian - for last 3 years.

Cmake will export all the C++ functions/classes for a  dll with one line
[KDAB - Create dlls on Windows without declspec() using new CMake export all feature - July 24, 2015](https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/)

To match Windows, Linux GNU can require all function references be resolved at link time

This commit supports building shared/static via cmake var

Resolves Issue 
Dynamic library #79
QXlsx as a DLL #49