### PR TITLE
Fix issue #164

### DIFF
--- a/QXlsx/source/xlsxrelationships.cpp
+++ b/QXlsx/source/xlsxrelationships.cpp
@@ -123,6 +123,8 @@ bool Relationships::loadFromXmlFile(QIODevice *device)
                  relationship.id = attributes.value(QLatin1String("Id")).toString();
                  relationship.type = attributes.value(QLatin1String("Type")).toString();
                  relationship.target = attributes.value(QLatin1String("Target")).toString();
+                 // issue #164 fix target path
+                 if(relationship.target.startsWith("/xl/worksheets")) relationship.target.remove(0,1);
                  relationship.targetMode = attributes.value(QLatin1String("TargetMode")).toString();
                  m_relationships.append(relationship);
              }

--- a/QXlsx/source/xlsxrelationships.cpp
+++ b/QXlsx/source/xlsxrelationships.cpp
@@ -124,7 +124,7 @@ bool Relationships::loadFromXmlFile(QIODevice *device)
                  relationship.type = attributes.value(QLatin1String("Type")).toString();
                  relationship.target = attributes.value(QLatin1String("Target")).toString();
                  // issue #164 fix target path
-                 if(relationship.target.startsWith("/xl/worksheets")) relationship.target.remove(0,1);
+                 if(relationship.target.startsWith("/xl")) relationship.target.remove(0,1);
                  relationship.targetMode = attributes.value(QLatin1String("TargetMode")).toString();
                  m_relationships.append(relationship);
              }

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -615,6 +615,8 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                  QString str = *( splitPath(strFilePath).begin() );
                  str = str + QLatin1String("/");
                  str = str + relationship.target;
+		 // issue #164 fix path
+                 if(str.startsWith("xl/xl/")) str.remove(0,3);
                  const QString fullPath = QDir::cleanPath( str );
 
                  sheet->setFilePath(fullPath);

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2556,7 +2556,7 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 		// issue #164 some xlsx files don't have r attr in c tag
                 if(r.isEmpty())
                 {
-                    cellTable[ rowX ][ columnY ] = cell;
+                    cellTable[ rowSum ][ columnSum ] = cell;
                 } else {
                     cellTable[ pos.row() ][ pos.column() ] = cell;
                 }


### PR DESCRIPTION
Some damn xlsx files in sheet xml files don't have r attr in c tag to 
get cell position on sheet, therefore i defined rowSum columnSum to 
count rows and columns manually according to their order in the sheet 
file. I know they may not be in the right order, but there isn't other 
way and Excel and libreoffice calc and others read these files in this 
way.

In addition in this type of xlsx files some paths in relation files 
isn't normal and the path contains full address that starts with '/' 
like /xl/workbook.xml that the zip reader can't find the file, i added 
some lines to remove the extra '/' from the beginning of path if exists. 
or some paths containt '/xl' in relations file and after parsing 
relations, become with '/xl/xl/' begining. like 
'xl/worksheets/sheet.xml' => '/xl/xl/worksheets/sheet.xml', i added some 
lines to remove extra '/xl' from the begining if exists.