### PR TITLE
Prevent unecessary temporary QString creations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,5 @@ ASALocalRun/
 /QXlsx/CMakeFiles/
 /QXlsx/Makefile
 
+# clangd cache
+.cache/

--- a/QXlsx/source/xlsxcellformula.cpp
+++ b/QXlsx/source/xlsxcellformula.cpp
@@ -423,7 +423,7 @@ bool CellFormula::loadFromXml(QXmlStreamReader &reader)
 
         if (attributes.hasAttribute(QLatin1String("si")))
         {
-            d->si = attributes.value(QLatin1String("si")).toString().toInt();
+            d->si = attributes.value(QLatin1String("si")).toInt();
         }
     }
 

--- a/QXlsx/source/xlsxchart.cpp
+++ b/QXlsx/source/xlsxchart.cpp
@@ -1479,7 +1479,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             if ( reader.name() == QLatin1String("axId") ) // mandatory element
             {
                 // dev57
-                uint axId = reader.attributes().value(QStringLiteral("val")).toString().toUInt(); // for Qt5.1
+                uint axId = reader.attributes().value(QStringLiteral("val")).toUInt(); // for Qt5.1
                 axis->axisId = axId;
             }
             else if ( reader.name() == QLatin1String("scaling") )
@@ -1550,7 +1550,7 @@ bool ChartPrivate::loadXmlAxisEG_AxShared(QXmlStreamReader &reader, XlsxAxis* ax
             else if ( reader.name() == QLatin1String("crossAx") ) // mandatory element
             {
                 // dev57
-                uint crossAx = reader.attributes().value(QLatin1String("val")).toString().toUInt(); // for Qt5.1
+                uint crossAx = reader.attributes().value(QLatin1String("val")).toUInt(); // for Qt5.1
                 axis->crossAx = crossAx;
             }
             else if ( reader.name() == QLatin1String("crosses") )

--- a/QXlsx/source/xlsxcolor.cpp
+++ b/QXlsx/source/xlsxcolor.cpp
@@ -95,7 +95,7 @@ bool XlsxColor::loadFromXml(QXmlStreamReader &reader)
         const auto& colorString = attributes.value(QLatin1String("rgb")).toString();
         val.setValue(fromARGBString(colorString));
     } else if (attributes.hasAttribute(QLatin1String("indexed"))) {
-        int index = attributes.value(QLatin1String("indexed")).toString().toInt();
+        int index = attributes.value(QLatin1String("indexed")).toInt();
         val.setValue(index);
     } else if (attributes.hasAttribute(QLatin1String("theme"))) {
         const auto& theme = attributes.value(QLatin1String("theme")).toString();

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -436,13 +436,13 @@ bool ConditionalFormattingPrivate::readCfRule(QXmlStreamReader &reader, XlsxCfRu
     if (attrs.hasAttribute(QLatin1String("type")))
         rule->attrs[XlsxCfRuleData::A_type] = attrs.value(QLatin1String("type")).toString();
     if (attrs.hasAttribute(QLatin1String("dxfId"))) {
-        int id = attrs.value(QLatin1String("dxfId")).toString().toInt();
+        int id = attrs.value(QLatin1String("dxfId")).toInt();
         if (styles)
             rule->dxfFormat = styles->dxfFormat(id);
         else
             rule->dxfFormat.setDxfIndex(id);
     }
-    rule->priority = attrs.value(QLatin1String("priority")).toString().toInt();
+    rule->priority = attrs.value(QLatin1String("priority")).toInt();
     if (attrs.value(QLatin1String("stopIfTrue")) == QLatin1String("1")) {
         //default is false
         rule->attrs[XlsxCfRuleData::A_stopIfTrue] = QLatin1String("1");

--- a/QXlsx/source/xlsxdrawinganchor.cpp
+++ b/QXlsx/source/xlsxdrawinganchor.cpp
@@ -122,8 +122,8 @@ QPoint DrawingAnchor::loadXmlPos(QXmlStreamReader &reader)
 
     QPoint pos;
     QXmlStreamAttributes attrs = reader.attributes();
-    pos.setX(attrs.value(QLatin1String("x")).toString().toInt());
-    pos.setY(attrs.value(QLatin1String("y")).toString().toInt());
+    pos.setX(attrs.value(QLatin1String("x")).toInt());
+    pos.setY(attrs.value(QLatin1String("y")).toInt());
     return pos;
 }
 
@@ -133,8 +133,8 @@ QSize DrawingAnchor::loadXmlExt(QXmlStreamReader &reader)
 
     QSize size;
     QXmlStreamAttributes attrs = reader.attributes();
-    size.setWidth(attrs.value(QLatin1String("cx")).toString().toInt());
-    size.setHeight(attrs.value(QLatin1String("cy")).toString().toInt());
+    size.setWidth(attrs.value(QLatin1String("cx")).toInt());
+    size.setHeight(attrs.value(QLatin1String("cy")).toInt());
     return size;
 }
 

--- a/QXlsx/source/xlsxsharedstrings.cpp
+++ b/QXlsx/source/xlsxsharedstrings.cpp
@@ -301,9 +301,9 @@ Format SharedStrings::readRichStringPart_rPr(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("rFont")) {
                 format.setFontName(attributes.value(QLatin1String("val")).toString());
             } else if (reader.name() == QLatin1String("charset")) {
-                format.setProperty(FormatPrivate::P_Font_Charset, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Charset, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("family")) {
-                format.setProperty(FormatPrivate::P_Font_Family, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Family, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("b")) {
                 format.setFontBold(true);
             } else if (reader.name() == QLatin1String("i")) {
@@ -315,15 +315,15 @@ Format SharedStrings::readRichStringPart_rPr(QXmlStreamReader &reader)
             } else if (reader.name() == QLatin1String("shadow")) {
                 format.setProperty(FormatPrivate::P_Font_Shadow, true);
             } else if (reader.name() == QLatin1String("condense")) {
-                format.setProperty(FormatPrivate::P_Font_Condense, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Condense, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("extend")) {
-                format.setProperty(FormatPrivate::P_Font_Extend, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Extend, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("color")) {
                 XlsxColor color;
                 color.loadFromXml(reader);
                 format.setProperty(FormatPrivate::P_Font_Color, color);
             } else if (reader.name() == QLatin1String("sz")) {
-                format.setFontSize(attributes.value(QLatin1String("val")).toString().toInt());
+                format.setFontSize(attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("u")) {
                 QString value = attributes.value(QLatin1String("val")).toString();
                 if (value == QLatin1String("double"))
@@ -359,7 +359,7 @@ bool SharedStrings::loadFromXmlFile(QIODevice *device)
              if (reader.name() == QLatin1String("sst")) {
                  QXmlStreamAttributes attributes = reader.attributes();
                  if ((hasUniqueCountAttr = attributes.hasAttribute(QLatin1String("uniqueCount"))))
-                     count = attributes.value(QLatin1String("uniqueCount")).toString().toInt();
+                     count = attributes.value(QLatin1String("uniqueCount")).toInt();
              } else if (reader.name() == QLatin1String("si")) {
                  readString(reader);
              }

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -759,7 +759,7 @@ bool Styles::readNumFmts(QXmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("numFmts"));
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
 
     //Read utill we find the numFmts end tag or ....
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
@@ -769,7 +769,7 @@ bool Styles::readNumFmts(QXmlStreamReader &reader)
             if (reader.name() == QLatin1String("numFmt")) {
                 const auto& attributes = reader.attributes();
                 QSharedPointer<XlsxFormatNumberData> fmt (new XlsxFormatNumberData);
-                fmt->formatIndex = attributes.value(QLatin1String("numFmtId")).toString().toInt();
+                fmt->formatIndex = attributes.value(QLatin1String("numFmtId")).toInt();
                 fmt->formatString = attributes.value(QLatin1String("formatCode")).toString();
                 if (fmt->formatIndex >= m_nextCustomNumFmtId)
                     m_nextCustomNumFmtId = fmt->formatIndex + 1;
@@ -793,7 +793,7 @@ bool Styles::readFonts(QXmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("fonts"));
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("fonts"))) {
         reader.readNextStartElement();
@@ -827,9 +827,9 @@ bool Styles::readFont(QXmlStreamReader &reader, Format &format)
             if (reader.name() == QLatin1String("name")) {
                 format.setFontName(attributes.value(QLatin1String("val")).toString());
             } else if (reader.name() == QLatin1String("charset")) {
-                format.setProperty(FormatPrivate::P_Font_Charset, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Charset, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("family")) {
-                format.setProperty(FormatPrivate::P_Font_Family, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Family, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("b")) {
                 format.setFontBold(true);
             } else if (reader.name() == QLatin1String("i")) {
@@ -841,15 +841,15 @@ bool Styles::readFont(QXmlStreamReader &reader, Format &format)
             } else if (reader.name() == QLatin1String("shadow")) {
                 format.setProperty(FormatPrivate::P_Font_Shadow, true);
             } else if (reader.name() == QLatin1String("condense")) {
-                format.setProperty(FormatPrivate::P_Font_Condense, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Condense, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("extend")) {
-                format.setProperty(FormatPrivate::P_Font_Extend, attributes.value(QLatin1String("val")).toString().toInt());
+                format.setProperty(FormatPrivate::P_Font_Extend, attributes.value(QLatin1String("val")).toInt());
             } else if (reader.name() == QLatin1String("color")) {
                 XlsxColor color;
                 color.loadFromXml(reader);
                 format.setProperty(FormatPrivate::P_Font_Color, color);
             } else if (reader.name() == QLatin1String("sz")) {
-                const auto sz = attributes.value(QLatin1String("val")).toString().toInt();
+                const auto sz = attributes.value(QLatin1String("val")).toInt();
                 format.setFontSize(sz);
             } else if (reader.name() == QLatin1String("u")) {
                 QString value = attributes.value(QLatin1String("val")).toString();
@@ -881,7 +881,7 @@ bool Styles::readFills(QXmlStreamReader &reader)
 
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("fills"))) {
         reader.readNextStartElement();
@@ -978,7 +978,7 @@ bool Styles::readBorders(QXmlStreamReader &reader)
 
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                && reader.name() == QLatin1String("borders"))) {
         reader.readNextStartElement();
@@ -1110,7 +1110,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("cellXfs"));
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                 && reader.name() == QLatin1String("cellXfs"))) {
         reader.readNextStartElement();
@@ -1125,7 +1125,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 //            qDebug()<<"... "<<i<<" "<<xfAttrs[i].name()<<xfAttrs[i].value();
 
                 if (xfAttrs.hasAttribute(QLatin1String("numFmtId"))) {
-                    const auto numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toString().toInt();
+                    const auto numFmtIndex = xfAttrs.value(QLatin1String("numFmtId")).toInt();
                     const auto apply = parseXsdBoolean(xfAttrs.value(QLatin1String("applyNumberFormat")).toString());
                     if(apply) {
                         const auto& it = m_customNumFmtIdMap.constFind(numFmtIndex);
@@ -1137,7 +1137,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("fontId"))) {
-                    const auto fontIndex = xfAttrs.value(QLatin1String("fontId")).toString().toInt();
+                    const auto fontIndex = xfAttrs.value(QLatin1String("fontId")).toInt();
                     if (fontIndex >= m_fontsList.size()) {
                         qDebug("Error read styles.xml, cellXfs fontId");
                     } else {
@@ -1153,7 +1153,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("fillId"))) {
-                    const auto id = xfAttrs.value(QLatin1String("fillId")).toString().toInt();
+                    const auto id = xfAttrs.value(QLatin1String("fillId")).toInt();
                     if (id >= m_fillsList.size()) {
                         qDebug("Error read styles.xml, cellXfs fillId");
                     } else {
@@ -1178,7 +1178,7 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                 }
 
                 if (xfAttrs.hasAttribute(QLatin1String("borderId"))) {
-                    const auto id = xfAttrs.value(QLatin1String("borderId")).toString().toInt();
+                    const auto id = xfAttrs.value(QLatin1String("borderId")).toInt();
                     if (id >= m_bordersList.size()) {
                         qDebug("Error read styles.xml, cellXfs borderId");
                     } else {
@@ -1228,12 +1228,12 @@ bool Styles::readCellXfs(QXmlStreamReader &reader)
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("indent"))) {
-                            const auto indent = alignAttrs.value(QLatin1String("indent")).toString().toInt();
+                            const auto indent = alignAttrs.value(QLatin1String("indent")).toInt();
                             format.setIndent(indent);
                         }
 
                         if (alignAttrs.hasAttribute(QLatin1String("textRotation"))) {
-                            const auto rotation = alignAttrs.value(QLatin1String("textRotation")).toString().toInt();
+                            const auto rotation = alignAttrs.value(QLatin1String("textRotation")).toInt();
                             format.setRotation(rotation);
                         }
 
@@ -1265,7 +1265,7 @@ bool Styles::readDxfs(QXmlStreamReader &reader)
     Q_ASSERT(reader.name() == QLatin1String("dxfs"));
     const auto& attributes = reader.attributes();
     const auto hasCount = attributes.hasAttribute(QLatin1String("count"));
-    const auto count = hasCount ? attributes.value(QLatin1String("count")).toString().toInt() : -1;
+    const auto count = hasCount ? attributes.value(QLatin1String("count")).toInt() : -1;
     while (!reader.atEnd() && !(reader.tokenType() == QXmlStreamReader::EndElement
                                 && reader.name() == QLatin1String("dxfs"))) {
         reader.readNextStartElement();
@@ -1292,7 +1292,7 @@ bool Styles::readDxf(QXmlStreamReader &reader)
         if (reader.tokenType() == QXmlStreamReader::StartElement) {
             if (reader.name() == QLatin1String("numFmt")) {
                 const auto& attributes = reader.attributes();
-                const auto id = attributes.value(QLatin1String("numFmtId")).toString().toInt();
+                const auto id = attributes.value(QLatin1String("numFmtId")).toInt();
                 QString code = attributes.value(QLatin1String("formatCode")).toString();
                 format.setNumberFormat(id, code);
             } else if (reader.name() == QLatin1String("font")) {

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -571,7 +571,7 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
 
                  const auto& name = attributes.value(QLatin1String("name")).toString();
 
-                 int sheetId = attributes.value(QLatin1String("sheetId")).toString().toInt();
+                 int sheetId = attributes.value(QLatin1String("sheetId")).toInt();
 
                  const auto& rId = attributes.value(QLatin1String("r:id")).toString();
 
@@ -637,17 +637,17 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                         {
                             QXmlStreamAttributes attrs = reader.attributes();
                             if (attrs.hasAttribute(QLatin1String("xWindow")))
-                                d->x_window = attrs.value(QLatin1String("xWindow")).toString().toInt();
+                                d->x_window = attrs.value(QLatin1String("xWindow")).toInt();
                             if (attrs.hasAttribute(QLatin1String("yWindow")))
-                                d->y_window = attrs.value(QLatin1String("yWindow")).toString().toInt();
+                                d->y_window = attrs.value(QLatin1String("yWindow")).toInt();
                             if (attrs.hasAttribute(QLatin1String("windowWidth")))
-                                d->window_width = attrs.value(QLatin1String("windowWidth")).toString().toInt();
+                                d->window_width = attrs.value(QLatin1String("windowWidth")).toInt();
                             if (attrs.hasAttribute(QLatin1String("windowHeight")))
-                                d->window_height = attrs.value(QLatin1String("windowHeight")).toString().toInt();
+                                d->window_height = attrs.value(QLatin1String("windowHeight")).toInt();
                             if (attrs.hasAttribute(QLatin1String("firstSheet")))
-                                d->firstsheet = attrs.value(QLatin1String("firstSheet")).toString().toInt();
+                                d->firstsheet = attrs.value(QLatin1String("firstSheet")).toInt();
                             if (attrs.hasAttribute(QLatin1String("activeTab")))
-                                d->activesheetIndex = attrs.value(QLatin1String("activeTab")).toString().toInt();
+                                d->activesheetIndex = attrs.value(QLatin1String("activeTab")).toInt();
                         }
                     }
                 }
@@ -675,7 +675,7 @@ bool Workbook::loadFromXmlFile(QIODevice *device)
                  if (attrs.hasAttribute(QLatin1String("comment")))
                      data.comment = attrs.value(QLatin1String("comment")).toString();
                  if (attrs.hasAttribute(QLatin1String("localSheetId"))) {
-                     int localId = attrs.value(QLatin1String("localSheetId")).toString().toInt();
+                     int localId = attrs.value(QLatin1String("localSheetId")).toInt();
                      int sheetId = d->sheets.at(localId)->sheetId();
                      data.sheetId = sheetId;
                  }

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2358,7 +2358,7 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
                     if (attributes.hasAttribute(QLatin1String("customFormat")) &&
                             attributes.hasAttribute(QLatin1String("s")))
                     {
-						int idx = attributes.value(QLatin1String("s")).toString().toInt();
+						int idx = attributes.value(QLatin1String("s")).toInt();
 						info->format = workbook->styles()->xfFormat(idx);
 					}
 
@@ -2368,7 +2368,7 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 						//Row height is only specified when customHeight is set
                         if(attributes.hasAttribute(QLatin1String("ht")))
                         {
-							info->height = attributes.value(QLatin1String("ht")).toString().toDouble();
+							info->height = attributes.value(QLatin1String("ht")).toDouble();
 						}
 					}
 
@@ -2377,12 +2377,12 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 					info->collapsed = attributes.value(QLatin1String("collapsed")) == QLatin1String("1");
 
 					if (attributes.hasAttribute(QLatin1String("outlineLevel")))
-						info->outlineLevel = attributes.value(QLatin1String("outlineLevel")).toString().toInt();
+						info->outlineLevel = attributes.value(QLatin1String("outlineLevel")).toInt();
 
 					//"r" is optional too.
                     if (attributes.hasAttribute(QLatin1String("r")))
                     {
-						int row = attributes.value(QLatin1String("r")).toString().toInt();
+						int row = attributes.value(QLatin1String("r")).toInt();
 						rowsInfo[row] = info;
 					}
 				}
@@ -2402,7 +2402,7 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 				if (attributes.hasAttribute(QLatin1String("s"))) // Style (defined in the styles.xml file)
 				{ 
 					//"s" == style index
-					int idx = attributes.value(QLatin1String("s")).toString().toInt();
+					int idx = attributes.value(QLatin1String("s")).toInt();
 					format = workbook->styles()->xfFormat(idx);
 					styleIndex = idx;
 				}
@@ -2412,7 +2412,7 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 
 				if (attributes.hasAttribute(QLatin1String("t"))) // Type 
 				{
-					QString typeString = attributes.value(QLatin1String("t")).toString();
+					const QStringRef typeString = attributes.value(QLatin1String("t"));
                     if (typeString == QLatin1String("s")) // Shared string
 					{
 						cellType = Cell::SharedStringType; 
@@ -2567,8 +2567,8 @@ void WorksheetPrivate::loadXmlColumnsInfo(QXmlStreamReader &reader)
                 QSharedPointer<XlsxColumnInfo> info(new XlsxColumnInfo(0, 1, false));
 
 				QXmlStreamAttributes colAttrs = reader.attributes();
-				int min = colAttrs.value(QLatin1String("min")).toString().toInt();
-				int max = colAttrs.value(QLatin1String("max")).toString().toInt();
+				int min = colAttrs.value(QLatin1String("min")).toInt();
+				int max = colAttrs.value(QLatin1String("max")).toInt();
 				info->firstColumn = min;
 				info->lastColumn = max;
 
@@ -2583,7 +2583,7 @@ void WorksheetPrivate::loadXmlColumnsInfo(QXmlStreamReader &reader)
                 // [dev54]
                 if (colAttrs.hasAttribute(QLatin1String("width")))
                 {
-					double width = colAttrs.value(QLatin1String("width")).toString().toDouble();
+					double width = colAttrs.value(QLatin1String("width")).toDouble();
 					info->width = width;
                     info->isSetWidth = true; // [dev54]
 				}
@@ -2593,13 +2593,13 @@ void WorksheetPrivate::loadXmlColumnsInfo(QXmlStreamReader &reader)
 
                 if (colAttrs.hasAttribute(QLatin1String("style")))
                 {
-					int idx = colAttrs.value(QLatin1String("style")).toString().toInt();
+					int idx = colAttrs.value(QLatin1String("style")).toInt();
 					info->format = workbook->styles()->xfFormat(idx);
 				}
 
 				if (colAttrs.hasAttribute(QLatin1String("outlineLevel")))
                 {
-					info->outlineLevel = colAttrs.value(QLatin1String("outlineLevel")).toString().toInt();
+					info->outlineLevel = colAttrs.value(QLatin1String("outlineLevel")).toInt();
                 }
 
                 // qDebug() << "[debug] " << __FUNCTION__ << min << max << info->width << hasWidth;
@@ -2630,7 +2630,7 @@ void WorksheetPrivate::loadXmlMergeCells(QXmlStreamReader &reader)
     }
     else
     {
-        count = attributes.value(QLatin1String("count")).toString().toInt();
+        count = attributes.value(QLatin1String("count")).toInt();
     }
 
     while ( !reader.atEnd() &&
@@ -2664,7 +2664,7 @@ void WorksheetPrivate::loadXmlDataValidations(QXmlStreamReader &reader)
 {
 	Q_ASSERT(reader.name() == QLatin1String("dataValidations"));
 	QXmlStreamAttributes attributes = reader.attributes();
-	int count = attributes.value(QLatin1String("count")).toString().toInt();
+	int count = attributes.value(QLatin1String("count")).toInt();
 
 	while (!reader.atEnd() && !(reader.name() == QLatin1String("dataValidations")
 			&& reader.tokenType() == QXmlStreamReader::EndElement)) {
@@ -2717,7 +2717,7 @@ void WorksheetPrivate::loadXmlSheetFormatProps(QXmlStreamReader &reader)
     {
         if(attrib.name() == QLatin1String("baseColWidth") )
         {
-			formatProps.baseColWidth = attrib.value().toString().toInt();
+			formatProps.baseColWidth = attrib.value().toInt();
         }
         else if(attrib.name() == QLatin1String("customHeight"))
         {
@@ -2725,21 +2725,21 @@ void WorksheetPrivate::loadXmlSheetFormatProps(QXmlStreamReader &reader)
         }
         else if(attrib.name() == QLatin1String("defaultColWidth"))
         {
-            double dDefaultColWidth = attrib.value().toString().toDouble();
+            double dDefaultColWidth = attrib.value().toDouble();
             formatProps.defaultColWidth = dDefaultColWidth;
             isSetWidth = true;
         }
         else if(attrib.name() == QLatin1String("defaultRowHeight"))
         {
-			formatProps.defaultRowHeight = attrib.value().toString().toDouble();
+			formatProps.defaultRowHeight = attrib.value().toDouble();
         }
         else if(attrib.name() == QLatin1String("outlineLevelCol"))
         {
-			formatProps.outlineLevelCol = attrib.value().toString().toInt();
+			formatProps.outlineLevelCol = attrib.value().toInt();
         }
         else if(attrib.name() == QLatin1String("outlineLevelRow"))
         {
-			formatProps.outlineLevelRow = attrib.value().toString().toInt();
+			formatProps.outlineLevelRow = attrib.value().toInt();
         }
         else if(attrib.name() == QLatin1String("thickBottom"))
         {


### PR DESCRIPTION
Use the `QStringRef::toInt() / QStringRef::toDouble()` methods directly