### PR TITLE
Prevent unecessary Cell object creations

### DIFF
--- a/QXlsx/header/xlsxcell.h
+++ b/QXlsx/header/xlsxcell.h
@@ -73,6 +73,8 @@ public:
 
 	qint32 styleNumber() const;
 
+	static bool isDateType(CellType cellType, const Format &format);
+
 };
 
 QT_END_NAMESPACE_XLSX

--- a/QXlsx/source/xlsxcell.cpp
+++ b/QXlsx/source/xlsxcell.cpp
@@ -350,4 +350,15 @@ qint32 Cell::styleNumber() const
 	return ret; 
 }
 
+bool Cell::isDateType(CellType cellType, const Format &format)
+{
+    if ( cellType == NumberType ||
+         cellType == DateType ||
+         cellType == CustomType )
+    {
+        return format.isValid() && format.isDateTimeFormat();
+    }
+	return false;
+}
+
 QT_END_NAMESPACE_XLSX

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2448,12 +2448,10 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 					}
 				}
 
-                // [dev54] temp cell for checking datetype
-                Cell tempCell(QVariant(), cellType, format, q, styleIndex);
-                if ( tempCell.isDateTime() )
-                {
-                    cellType = Cell::DateType;
-                }
+				if (Cell::isDateType(cellType, format))
+				{
+					cellType = Cell::DateType;
+				}
 
 				// create a heap of new cell
 				QSharedPointer<Cell> cell(new Cell(QVariant(), cellType, format, q, styleIndex));
@@ -3003,7 +3001,6 @@ void WorksheetPrivate::validateDimension()
         {
             lastColumn = (--it.value().constEnd()).key();
         }
-
     }
 
 	CellRange cr(firstRow, firstColumn, lastRow, lastColumn);


### PR DESCRIPTION
A static method can do the same thing without creating anything