### PR TITLE
Fix datetimeFromNumber() issue with std::modf float/double

### DIFF
--- a/QXlsx/source/xlsxutility.cpp
+++ b/QXlsx/source/xlsxutility.cpp
@@ -108,8 +108,8 @@ QVariant datetimeFromNumber(double num, bool is1904)
     }
 #endif
 
-    float whole = 0;
-    float fractional = std::modf(num, &whole);
+    double whole = 0;
+    double fractional = std::modf(num, &whole);
 
     if ( num < double(1) )
     {


### PR DESCRIPTION
modf of double often returns float of 0.0, so then return QDate except of QDateTime


