### PR TITLE
Fix StringsToNumbersEnabled not working

### DIFF
--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -450,7 +450,7 @@ bool Worksheet::write(int row, int column, const QVariant &value, const Format &
         else if (d->workbook->isStringsToNumbersEnabled() && (value.toDouble(&ok), ok))
         {
 			//Try convert string to number if the flag enabled.
-			ret = writeString(row, column, value.toString(), format);
+			ret = writeNumeric(row, column, value.toDouble(), format);
         }
         else
         {

--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -3003,7 +3003,6 @@ void WorksheetPrivate::validateDimension()
         {
             lastColumn = (--it.value().constEnd()).key();
         }
-
     }
 
 	CellRange cr(firstRow, firstColumn, lastRow, lastColumn);


### PR DESCRIPTION
Checking to see if the value to write is a double then not writing it as a double is incorrect and doesn't even match the comment directly above the incorrect code.