### PR TITLE
Added option to install library in a common way

### DIFF
--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -50,3 +50,30 @@ target_link_libraries(${PROJECT_NAME}
  )
 
 target_compile_definitions(QXlsx PRIVATE QXLSX_LIBRARY)
+
+# install the library on a system
+include(GNUInstallDirs)
+install(FILES ${QXLSX_H} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qxlsx)
+install(
+    TARGETS QXlsx
+    EXPORT QXlsxTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+    EXPORT QXlsxTargets
+    FILE QXlsxTargets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QXlsx
+    NAMESPACE QXlsx::
+)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/QXlsxConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/QXlsxConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QXlsx
+)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/QXlsxConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QXlsx
+)

--- a/QXlsx/cmake/QXlsxConfig.cmake.in
+++ b/QXlsx/cmake/QXlsxConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+@PACKAGE_DEPENDENCIES@
+
+# Add the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/QXlsxTargets.cmake")
+
+check_required_components(QXlsx)


### PR DESCRIPTION
This change allows to install QXlsx library on a system with ```sudo make install``` command.