### PR TITLE
fix:Fix the residual problem after sheet creation fails

### DIFF
--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -207,6 +207,7 @@ AbstractSheet *Workbook::addSheet(const QString &name, int sheetId, AbstractShee
     {
         qWarning("unsupported sheet type.");
         Q_ASSERT(false);
+		return sheet;
     }
 
     d->sheets.append(QSharedPointer<AbstractSheet>(sheet));
@@ -259,6 +260,7 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
     {
         qWarning("unsupported sheet type.");
         Q_ASSERT(false);
+		return sheet;
     }
 
     d->sheets.insert(index, QSharedPointer<AbstractSheet>(sheet));

--- a/QXlsx/source/xlsxworkbook.cpp
+++ b/QXlsx/source/xlsxworkbook.cpp
@@ -207,7 +207,7 @@ AbstractSheet *Workbook::addSheet(const QString &name, int sheetId, AbstractShee
     {
         qWarning("unsupported sheet type.");
         Q_ASSERT(false);
-		return sheet;
+	return sheet;
     }
 
     d->sheets.append(QSharedPointer<AbstractSheet>(sheet));
@@ -260,7 +260,7 @@ AbstractSheet *Workbook::insertSheet(int index, const QString &name, AbstractShe
     {
         qWarning("unsupported sheet type.");
         Q_ASSERT(false);
-		return sheet;
+	return sheet;
     }
 
     d->sheets.insert(index, QSharedPointer<AbstractSheet>(sheet));


### PR DESCRIPTION
Since ST_DialogSheet and ST_MacroSheet are not yet supported;
If ST_DialogSheet or ST_MacroSheet is created in Release mode, it will fail, and if Q_ASSERT fails in Release mode, it will cause sheetNames to add an uncreated sheetName;