### PR TITLE
Drop Qt5.9 and older support

### DIFF
--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_AUTOMOC ON)
 include(GNUInstallDirs)
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} 5.10 COMPONENTS Core Gui REQUIRED)
 
 if (QT_MAJOR_VERSION EQUAL 6)
     set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
@@ -160,8 +160,9 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 target_link_libraries(${PROJECT_NAME}
-   Qt${QT_VERSION_MAJOR}::Core
-   Qt${QT_VERSION_MAJOR}::GuiPrivate
+    PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::GuiPrivate
 )
 
 target_include_directories(QXlsx

--- a/QXlsx/header/xlsxcellrange.h
+++ b/QXlsx/header/xlsxcellrange.h
@@ -18,8 +18,7 @@ public:
     CellRange();
     CellRange(int firstRow, int firstColumn, int lastRow, int lastColumn);
     CellRange(const CellReference &topLeft, const CellReference &bottomRight);
-    CellRange(const QString &range);
-    CellRange(const char *range);
+    CellRange(QStringView range);
     CellRange(const CellRange &other);
     ~CellRange();
 
@@ -58,8 +57,6 @@ public:
                 || left != other.left || right != other.right;
     }
 private:
-    void init(const QString &range);
-
     int top;
     int left;
     int bottom;

--- a/QXlsx/header/xlsxcellreference.h
+++ b/QXlsx/header/xlsxcellreference.h
@@ -15,7 +15,7 @@ public:
     CellReference();
     CellReference(int row, int column);
     CellReference(const QString &cell);
-    CellReference(const char *cell);
+    CellReference(QStringView cell);
     CellReference(const CellReference &other);
     ~CellReference();
 

--- a/QXlsx/header/xlsxstyles_p.h
+++ b/QXlsx/header/xlsxstyles_p.h
@@ -78,9 +78,7 @@ public:
     void saveToXmlFile(QIODevice *device) const;
     bool loadFromXmlFile(QIODevice *device);
 
-#if QT_VERSION >= 0x050600
     QColor getColorByIndex(int idx);
-#endif
 
 private:
     friend class Format;

--- a/QXlsx/header/xlsxutility_p.h
+++ b/QXlsx/header/xlsxutility_p.h
@@ -21,7 +21,7 @@ QT_BEGIN_NAMESPACE_XLSX
 
 class CellReference;
 
-bool parseXsdBoolean(const QString &value, bool defaultValue=false);
+bool parseXsdBoolean(QStringView value, bool defaultValue=false);
 
 QStringList splitPath(const QString &path);
 QString getRelFilePath(const QString &filePath);

--- a/QXlsx/header/xlsxworksheet_p.h
+++ b/QXlsx/header/xlsxworksheet_p.h
@@ -10,11 +10,7 @@
 #include <QImage>
 #include <QSharedPointer>
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
-#else
-#include <QRegExp>
-#endif
 
 #include "xlsxworksheet.h"
 #include "xlsxabstractsheet_p.h"
@@ -238,6 +234,8 @@ public:
 
     XlsxSheetFormatProps sheetFormatProps;
 
+    QRegularExpression urlPattern;
+
     bool windowProtection;
     bool showFormulas;
     bool showGridLines;
@@ -248,12 +246,6 @@ public:
     bool showRuler;
     bool showOutlineSymbols;
     bool showWhiteSpace;
-
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
-    QRegularExpression urlPattern;
-#else
-    QRegExp urlPattern;
-#endif
 
 private:
 

--- a/QXlsx/header/xlsxzipreader_p.h
+++ b/QXlsx/header/xlsxzipreader_p.h
@@ -9,10 +9,6 @@
 
 #include "xlsxglobal.h"
 
-#if QT_VERSION >= 0x050600
- #include <QVector>
-#endif
-
 class QZipReader;
 
 QT_BEGIN_NAMESPACE_XLSX

--- a/QXlsx/source/xlsxcellrange.cpp
+++ b/QXlsx/source/xlsxcellrange.cpp
@@ -49,23 +49,9 @@ CellRange::CellRange(const CellReference &topLeft, const CellReference &bottomRi
     \overload
     Constructs the range form the given \a range string.
 */
-CellRange::CellRange(const QString &range)
+CellRange::CellRange(QStringView range)
 {
-    init(range);
-}
-
-/*!
-    \overload
-    Constructs the range form the given \a range string.
-*/
-CellRange::CellRange(const char *range)
-{
-    init(QString::fromLatin1(range));
-}
-
-void CellRange::init(const QString &range)
-{
-    QStringList rs = range.split(QLatin1Char(':'));
+    const auto rs = range.split(u':');
     if (rs.size() == 2) {
         CellReference start(rs[0]);
         CellReference end(rs[1]);

--- a/QXlsx/source/xlsxcellreference.cpp
+++ b/QXlsx/source/xlsxcellreference.cpp
@@ -4,11 +4,7 @@
 #include <QStringList>
 #include <QMap>
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
-#else
-#include <QRegExp>
-#endif
 
 QT_BEGIN_NAMESPACE_XLSX
 
@@ -95,14 +91,13 @@ CellReference::CellReference(const QString &cell)
     \overload
     Constructs the Reference form the given \a cell string.
 */
-CellReference::CellReference(const char *cell)
+CellReference::CellReference(QStringView cell)
 {
-    init(QString::fromLatin1(cell));
+    init(cell.toString());
 }
 
 void CellReference::init(const QString &cell_str)
 {
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     static thread_local QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
     QRegularExpressionMatch match = re.match(cell_str);
     if (match.hasMatch()) {
@@ -111,16 +106,6 @@ void CellReference::init(const QString &cell_str)
         _row = row_str.toInt();
         _column = col_from_name(col_str);
     }
-#else
-    QRegExp re(QLatin1String("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
-    if (re.indexIn(cell_str) != -1)
-    {
-       const QString col_str = re.cap(1);
-       const QString row_str = re.cap(2);
-       _row = row_str.toInt();
-       _column = col_from_name(col_str);
-    }
-#endif
 }
 
 /*!

--- a/QXlsx/source/xlsxcolor.cpp
+++ b/QXlsx/source/xlsxcolor.cpp
@@ -119,67 +119,21 @@ XlsxColor::operator QVariant() const
 
 QColor XlsxColor::fromARGBString(const QString &c)
 {
-    // issue #173 https://github.com/QtExcel/QXlsx/issues/173
-
     QColor color;
-    QString strColor = QStringLiteral("00000000");
 
-    if ( c.length() == 8 )
+    if (c.startsWith(u'#'))
     {
-        strColor = c;
+        color.setNamedColor(c);
+    } else {
+        color.setNamedColor(QLatin1Char('#') + c);
     }
-
-    if ( c.length() == 6 )
-    {
-        strColor = QLatin1String("00") + c;
-    }
-
-#if QT_VERSION >= 0x060000 // Qt 6.0 or over
-    QString strAlpha = strColor.mid(0, 2);
-    int alpha = strAlpha.toInt(0, 16);
-    color.setAlpha( alpha );
-
-    QString strRed = strColor.mid(2, 2);
-    int red = strRed.toInt(0, 16);
-    color.setRed( red );
-
-    QString strGreen = strColor.mid(4, 2);
-    int green = strGreen.toInt(0, 16);
-    color.setGreen( green );
-
-    QString strBlue = strColor.mid(6, 2);
-    int blue = strBlue.toInt(0, 16);
-    color.setBlue( blue );
-#else
-    QStringRef strAlpha = strColor.midRef(0, 2);
-    int alpha = strAlpha.toInt(0, 16);
-    color.setAlpha( alpha );
-
-    QStringRef strRed = strColor.midRef(2, 2);
-    int red = strRed.toInt(0, 16);
-    color.setRed( red );
-
-    QStringRef strGreen = strColor.midRef(4, 2);
-    int green = strGreen.toInt(0, 16);
-    color.setGreen( green );
-
-    QStringRef strBlue = strColor.midRef(6, 2);
-    int blue = strBlue.toInt(0, 16);
-    color.setBlue( blue );
-#endif
 
     return color;
 }
 
 QString XlsxColor::toARGBString(const QColor &c)
 {
-#if QT_VERSION >= 0x050600 // Qt 5.6 or over
     return QString::asprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
-#else
-    QString color;
-    color.sprintf("%02X%02X%02X%02X", c.alpha(), c.red(), c.green(), c.blue());
-    return color;
-#endif
 }
 
 #if !defined(QT_NO_DATASTREAM)

--- a/QXlsx/source/xlsxconditionalformatting.cpp
+++ b/QXlsx/source/xlsxconditionalformatting.cpp
@@ -610,9 +610,9 @@ bool ConditionalFormatting::loadFromXml(QXmlStreamReader &reader, Styles *styles
     d->cfRules.clear();
     QXmlStreamAttributes attrs = reader.attributes();
     const QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    const auto sqrefParts = sqref.split(QLatin1Char(' '));
-    for (const QString &range : sqrefParts) {
-        this->addRange(range);
+    const auto sqrefParts = sqref.split(u' ');
+    for (const auto &range : sqrefParts) {
+        addRange(CellRange{range});
     }
 
     while (!reader.atEnd()) {
@@ -722,9 +722,15 @@ bool ConditionalFormatting::saveToXml(QXmlStreamWriter &writer) const
 
         it = rule->attrs.constFind(XlsxCfRuleData::A_formula1_temp);
         if (it != rule->attrs.constEnd()) {
-            QString str = ( ranges().begin() )->toString();
-            QString startCell = *( str.split(QLatin1Char(':')).begin() );
-            writer.writeTextElement(QStringLiteral("formula"), it.value().toString().arg(startCell));
+            const auto _ranges = ranges();
+            if (!_ranges.isEmpty()) {
+                const QString str = _ranges.first().toString();
+                const int ix = str.indexOf(u':');
+                if (ix != -1) {
+                    const QString startCell = str.left(ix);
+                    writer.writeTextElement(QStringLiteral("formula"), it.value().toString().arg(startCell));
+                }
+            }
         } else if ((it = rule->attrs.constFind(XlsxCfRuleData::A_formula1)) != rule->attrs.constEnd()) {
             writer.writeTextElement(QStringLiteral("formula"), it.value().toString());
         }

--- a/QXlsx/source/xlsxdatavalidation.cpp
+++ b/QXlsx/source/xlsxdatavalidation.cpp
@@ -475,9 +475,9 @@ DataValidation DataValidation::loadFromXml(QXmlStreamReader &reader)
     QXmlStreamAttributes attrs = reader.attributes();
 
     QString sqref = attrs.value(QLatin1String("sqref")).toString();
-    const auto sqrefParts = sqref.split(QLatin1Char(' '));
-    for (const QString &range : sqrefParts)
-        validation.addRange(range);
+    const auto sqrefParts = sqref.split(u' ');
+    for (const auto range : sqrefParts)
+        validation.addRange(CellRange{range});
 
     if (attrs.hasAttribute(QLatin1String("type"))) {
         QString t = attrs.value(QLatin1String("type")).toString();

--- a/QXlsx/source/xlsxstyles.cpp
+++ b/QXlsx/source/xlsxstyles.cpp
@@ -54,9 +54,7 @@ Styles::Styles(CreateFlag flag)
 
         qRegisterMetaTypeStreamOperators<XlsxColor>("XlsxColor");
 
-    #if QT_VERSION >= 0x050200 // 5.2 or higher
-            QMetaType::registerDebugStreamOperator<XlsxColor>();
-    #endif
+        QMetaType::registerDebugStreamOperator<XlsxColor>();
 
 #endif
     }
@@ -1385,11 +1383,8 @@ bool Styles::loadFromXmlFile(QIODevice *device)
     return true;
 }
 
-#if QT_VERSION >= 0x050600
 QColor Styles::getColorByIndex(int idx)
 {
-    // #if QT_VERSION >= 0x050600
-
     if (m_indexedColors.isEmpty()) {
         m_indexedColors = {
             QColor(QRgba64::fromArgb32(0x000000)), QColor(QRgba64::fromArgb32(0xFFFFFF)), QColor(QRgba64::fromArgb32(0xFF0000)), QColor(QRgba64::fromArgb32(0x00FF00)),
@@ -1415,6 +1410,5 @@ QColor Styles::getColorByIndex(int idx)
         return QColor();
     return m_indexedColors[idx];
 }
-#endif
 
 QT_END_NAMESPACE_XLSX

--- a/QXlsx/source/xlsxutility.cpp
+++ b/QXlsx/source/xlsxutility.cpp
@@ -5,11 +5,7 @@
 
 #include <QString>
 #include <QPoint>
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
 #include <QRegularExpression>
-#else
-#include <QRegExp>
-#endif
 #include <QMap>
 #include <QStringList>
 #include <QColor>
@@ -21,11 +17,11 @@
 
 QT_BEGIN_NAMESPACE_XLSX
 
-bool parseXsdBoolean(const QString &value, bool defaultValue)
+bool parseXsdBoolean(QStringView value, bool defaultValue)
 {
-    if (value == QLatin1String("1") || value == QLatin1String("true"))
+    if (value == u"1" || value == u"true")
         return true;
-    if (value == QLatin1String("0") || value == QLatin1String("false"))
+    if (value == u"0" || value == u"false")
         return false;
     return defaultValue;
 }
@@ -67,10 +63,8 @@ double datetimeToNumber(const QDateTime &dt, bool is1904)
 
     double excel_time = epoch.msecsTo(dt) / (1000*60*60*24.0);
 
-#if QT_VERSION >= 0x050200
     if (dt.isDaylightTime())    // Add one hour if the date is Daylight
         excel_time += 1.0 / 24.0;
-#endif
 
     if (!is1904 && excel_time > 59) {//31+28
         //Account for Excel erroneously treating 1900 as a leap year.
@@ -99,14 +93,12 @@ QVariant datetimeFromNumber(double num, bool is1904)
     QDateTime dtOld = epoch.addMSecs(msecs);
     dtRet = dtOld;
 
-#if QT_VERSION >= 0x050200
     // Remove one hour to see whether the date is Daylight
     QDateTime dtNew = dtRet.addMSecs( -3600000 ); // issue102
     if ( dtNew.isDaylightTime() )
     {
         dtRet = dtNew;
     }
-#endif
 
     double whole = 0;
     double fractional = std::modf(num, &whole);
@@ -147,15 +139,12 @@ QString createSafeSheetName(const QString &nameProposal)
         ret = unescapeSheetName(ret);
 
     //Replace invalid chars with space.
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     if (nameProposal.contains(QRegularExpression(QStringLiteral("[/\\\\?*\\][:]"))))
         ret.replace(QRegularExpression(QStringLiteral("[/\\\\?*\\][:]")), QStringLiteral(" "));
-#else
-    if (nameProposal.contains(QRegExp(QLatin1String("[/\\\\?*\\][:]"))))
-        ret.replace(QRegExp(QLatin1String("[/\\\\?*\\][:]")), QLatin1String(" "));
-#endif
+
     if (ret.startsWith(QLatin1Char('\'')))
         ret[0] = QLatin1Char(' ');
+
     if (ret.endsWith(QLatin1Char('\'')))
         ret[ret.size()-1] = QLatin1Char(' ');
 
@@ -173,13 +162,8 @@ QString escapeSheetName(const QString &sheetName)
     Q_ASSERT(!sheetName.startsWith(QLatin1Char('\'')) && !sheetName.endsWith(QLatin1Char('\'')));
 
     //These is no need to escape
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 )
     if (!sheetName.contains(QRegularExpression(QStringLiteral("[ +\\-,%^=<>'&]"))))
         return sheetName;
-#else
-    if (!sheetName.contains(QRegExp(QLatin1String("[ +\\-,%^=<>'&]"))))
-        return sheetName;
-#endif
 
     //OK, escape is needed.
     QString name = sheetName;


### PR DESCRIPTION
QXlsx can't even be compiled for Qt4 and
there where still some Qt4 leftovers.

This adds basic QStringView usage where it
makes sense.