### PR TITLE
fix parsing of worksheets that lack column number / have invalid dimension

### DIFF
--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2261,6 +2261,9 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
 
     Q_ASSERT(reader.name() == QLatin1String("sheetData"));
 
+    int row_num = 0;
+    int col_num = 0;
+
     while (!reader.atEnd() && !(reader.name() == QLatin1String("sheetData") &&
                                 reader.tokenType() == QXmlStreamReader::EndElement)) {
         if (reader.readNextStartElement()) {
@@ -2305,6 +2308,12 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
                     }
                 }
 
+                if (attributes.hasAttribute(QLatin1String("r")))
+                    row_num = attributes.value(QLatin1String("r")).toInt();
+                else
+                    ++row_num;
+                col_num = 0;
+
             } else if (reader.name() == QLatin1String("c")) // Cell
             {
 
@@ -2312,6 +2321,11 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
                 QXmlStreamAttributes attributes = reader.attributes();
                 QString r                       = attributes.value(QLatin1String("r")).toString();
                 CellReference pos(r);
+                if (r.isEmpty())
+                {
+                    pos.setRow(row_num);
+                    pos.setColumn(++col_num);
+                }
 
                 // get format
                 Format format;
@@ -2433,6 +2447,12 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
             }
         }
     }
+
+    if (dimension.lastRow() < row_num)
+        dimension.setLastRow(row_num);
+
+    if (dimension.lastColumn() < col_num)
+        dimension.setLastColumn(col_num);
 }
 
 void WorksheetPrivate::loadXmlColumnsInfo(QXmlStreamReader &reader)


### PR DESCRIPTION
Fix parsing of worksheets that have invalid dimension and lack column names, for example:

`<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="x14ac" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"><dimension ref="A1"/><sheetViews><sheetView tabSelected="1" workbookViewId="0"/></sheetViews><sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/><sheetData xml:space="preserve"><row r="1"><c t="str"><v>Applied filters:
ip is 10.110.3.16</v></c></row><row r="2"><c></c></row><row r="3"><c t="str"><v>@timestamp</v></c><c t="str"><v>ip</v></c><c t="str"><v>facility</v></c><c t="str"><v>priority</v></c><c t="str"><v>seq</v></c><c t="str"><v>syslogmessage</v></c></row><row r="4"><c s="2"><v>44670.0836667014</v></c><c t="str"><v>10.110.3.16</v></c><c t="str"><v>local0</v></c><c t="str"><v>Warning</v></c><c s="6"><v>73460201</v></c><c t="str"><v>[S=3472640] [BID=0daeae:4]  sslFileGet - ctx 0: Failed to read file /var/AC/cert/0/root (error 2) [Time:19-04@01:59:59.034]</v></c></row>
`

Such files are produced by Azure Power BI / Log Analytics default export tool.

Excel opens such files just fine. And other XLSX parsers - e.g. Python's xlsx2csv - parse them correctly too.