### PR TITLE
fix QDateTime performance on Qt6

### DIFF
--- a/QXlsx/source/xlsxutility.cpp
+++ b/QXlsx/source/xlsxutility.cpp
@@ -80,20 +80,33 @@ double timeToNumber(const QTime &time)
     return QTime(0, 0).msecsTo(time) / (1000 * 60 * 60 * 24.0);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+static qint64 msecs1904 = QDateTime(QDate(1904, 1, 1), QTime(0, 0)).toMSecsSinceEpoch();
+static qint64 msecs1899 = QDateTime(QDate(1899, 12, 31), QTime(0, 0)).toMSecsSinceEpoch();
+#endif
+
 QVariant datetimeFromNumber(double num, bool is1904)
 {
-    QDateTime dtRet; // return value
-
     if (!is1904 && num > 60) // for mac os excel
     {
         num = num - 1;
     }
 
     qint64 msecs = static_cast<qint64>(num * 1000 * 60 * 60 * 24.0 + 0.5);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+    if (is1904)
+        msecs += msecs1904;
+    else
+        msecs += msecs1899;
+
+    QDateTime dtRet = QDateTime::fromMSecsSinceEpoch(msecs);
+#else
+    QDateTime dtRet; // return value
     QDateTime epoch(is1904 ? QDate(1904, 1, 1) : QDate(1899, 12, 31), QTime(0, 0));
     QDateTime dtOld = epoch.addMSecs(msecs);
     dtRet           = dtOld;
-
+#endif
     // Remove one hour to see whether the date is Daylight
     QDateTime dtNew = dtRet.addMSecs(-3600000); // issue102
     if (dtNew.isDaylightTime()) {


### PR DESCRIPTION
Switching from Qt 5.15.2 to Qt6.5.1 on Windows platform introduces HUGE performance regression in parsing of date fields when opening the XLSX files. On my laptop (i7-10510U, 32 GB RAM, Windows 10 Pro) opening of 2 MB file takes roughly 3 sec on Qt 5.15.2 and more than 3 minutes (!) on Qt 6.5.1.

The change seems to be related to some underlying changes in QDateTime class implementation - specifically performance of copy constructors seems to have degraded a lot in Qt6.

I was able to solve the problem by switching implementation of datetimeFromNumber() to new QDateTime::fromMSecsSinceEpoch() function introduced in Qt6.5.