### PR TITLE
QMap cell reference cache only makes code slower

### DIFF
--- a/QXlsx/source/xlsxcellreference.cpp
+++ b/QXlsx/source/xlsxcellreference.cpp
@@ -26,23 +26,16 @@ int intPow(int x, int p)
 
 QString col_to_name(int col_num)
 {
-    static thread_local QMap<int, QString> col_cache;
-
-    auto it = col_cache.find(col_num);
-    if (it == col_cache.end()) {
-        QString col_str;
-        int remainder;
-        while (col_num) {
-            remainder = col_num % 26;
-            if (remainder == 0)
-                remainder = 26;
-            col_str.prepend(QChar('A' + remainder - 1));
-            col_num = (col_num - 1) / 26;
-        }
-        it = col_cache.insert(col_num, col_str);
+    QString col_str;
+    int remainder;
+    while (col_num) {
+        remainder = col_num % 26;
+        if (remainder == 0)
+            remainder = 26;
+        col_str.prepend(QChar('A' + remainder - 1));
+        col_num = (col_num - 1) / 26;
     }
-
-    return it.value();
+    return col_str;
 }
 
 int col_from_name(const QString &col_str)
@@ -104,7 +97,7 @@ CellReference::CellReference(const char *cell)
 
 void CellReference::init(const QString &cell_str)
 {
-    static thread_local QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
+    static const QRegularExpression re(QStringLiteral("^\\$?([A-Z]{1,3})\\$?(\\d+)$"));
     QRegularExpressionMatch match = re.match(cell_str);
     if (match.hasMatch()) {
         const QString col_str = match.captured(1);
@@ -138,7 +131,7 @@ CellReference::~CellReference()
 QString CellReference::toString(bool row_abs, bool col_abs) const
 {
     if (!isValid())
-        return QString();
+        return {};
 
     QString cell_str;
     if (col_abs)


### PR DESCRIPTION
Benchmarking shows code is slower with it,
it's faster to just create the string.