### PR TITLE
Added showFormulas logic to Worksheet read method

### DIFF
--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -520,7 +520,7 @@ QVariant Worksheet::read(int row, int column) const
     if (!cell)
         return QVariant();
 
-    if (cell->hasFormula()) {
+    if (cell->hasFormula() && d->showFormulas) {
         if (cell->formula().formulaType() == CellFormula::NormalType) {
             return QVariant(QLatin1String("=") + cell->formula().formulaText());
         } else if (cell->formula().formulaType() == CellFormula::SharedType) {


### PR DESCRIPTION
When reading from a worksheet, sometimes we want to get the value of the cell even though a formula text is present. I have added logic to check showFormulas property in read method of Worksheet to decide whether to return the cell value or cell formula text.