### PR TITLE
If there is no ht, then the property of customHeight is false

### DIFF
--- a/QXlsx/source/xlsxworksheet.cpp
+++ b/QXlsx/source/xlsxworksheet.cpp
@@ -2279,6 +2279,10 @@ void WorksheetPrivate::loadXmlSheetData(QXmlStreamReader &reader)
                         if (attributes.hasAttribute(QLatin1String("ht"))) {
                             info->height = attributes.value(QLatin1String("ht")).toDouble();
                         }
+						else
+                        {
+                            info->customHeight = false;
+                        }
                     }
 
                     // both "hidden" and "collapsed" default are false


### PR DESCRIPTION
If row does not have the ht attribute but has the customHeight attribute, the row will be hidden; In fact, there is no need to hide it