### PR TITLE
Fix MSVC build issues for version 1.5.1 release

### DIFF
--- a/ExcelViewer/mainwindow.cpp
+++ b/ExcelViewer/mainwindow.cpp
@@ -16,9 +16,6 @@
 
 using namespace QXlsx;
 
-// Hard-coded QXlsx version string (based on the library you are using)
-// static const char *QXLSX_VERSION = "1.5.0";
-
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
 {

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(QXlsx
-    VERSION 1.5.0
+    VERSION 1.5.1
     LANGUAGES CXX
 )
 

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -158,6 +158,12 @@ target_compile_definitions(QXlsx PRIVATE
     QT_DISABLE_DEPRECATED_BEFORE=0x060600
 )
 
+if(MSVC)
+    # Disable strict MSVC compliance mode to prevent build errors 
+    # caused by standard library ('stdext') changes in newer MSVC compilers with older Qt headers.
+    target_compile_options(QXlsx PRIVATE /permissive)
+endif()
+
 if (NOT WIN32)
     # Strict iterators can't be used on Windows, they lead to a link error
     # when application code iterates over a QVector<QPoint> for instance, unless

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -159,9 +159,8 @@ target_compile_definitions(QXlsx PRIVATE
 )
 
 if(MSVC)
-    # Disable strict MSVC compliance mode to prevent build errors 
-    # caused by standard library ('stdext') changes in newer MSVC compilers with older Qt headers.
-    target_compile_options(QXlsx PRIVATE /permissive)
+    # Fix 'stdext' errors by allowing mismatch between newer MSVC toolset and older Qt/STL headers
+    target_compile_definitions(QXlsx PRIVATE _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
 endif()
 
 if (NOT WIN32)

--- a/QXlsx/QXlsx.pri
+++ b/QXlsx/QXlsx.pri
@@ -5,8 +5,17 @@
 QT += core
 QT += gui-private
 
-# TODO: Define your C++ version. c++14, c++17, etc.
-CONFIG += c++11
+# Define your C++ version.
+# Safe method using built-in variables without brackets
+lessThan(QT_MAJOR_VERSION, 6) {
+    # Set C++11 for Qt 5 (5.7 or higher version)
+    CONFIG += c++11
+    message("Qt 5 detected: Setting C++ standard to C++11")
+} else {
+    # Set C++17 for Qt 6
+    CONFIG += c++17
+    message("Qt 6 detected: Setting C++ standard to C++17")
+}
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings

--- a/QXlsx/QXlsx.pro
+++ b/QXlsx/QXlsx.pro
@@ -29,10 +29,4 @@ QXLSX_HEADERPATH=$$PWD/header/
 QXLSX_SOURCEPATH=$$PWD/source/
 include($$PWD/QXlsx.pri)
 
-HEADERS += \
-    header/xlsxreadsax.h
-
-SOURCES += \
-    source/xlsxreadsax.cpp
-
 


### PR DESCRIPTION
This pull request updates the QXlsx library to improve compatibility, update versioning, and clean up configuration. The most important changes are grouped below:

**Build system and compatibility improvements:**

* Updated the QXlsx project version from `1.5.0` to `1.5.1` in `QXlsx/CMakeLists.txt` to reflect the new release.
* Added a conditional definition for `_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH` when building with MSVC to resolve 'stdext' errors caused by mismatched toolset and Qt/STL header versions.
* Improved C++ standard selection in `QXlsx.pri`: now sets C++11 for Qt 5 and C++17 for Qt 6, with informative messages during the build.

**Code and configuration cleanup:**

* Removed hard-coded QXlsx version string from `mainwindow.cpp` as it is now managed by the build system.
* Cleaned up `QXlsx.pro` by removing explicit inclusion of `xlsxreadsax.h` and `xlsxreadsax.cpp` from the HEADERS and SOURCES lists, likely because these are now handled elsewhere.