### PR TITLE
Update MSVC compiler options and CMake configuration for 1.5.1

### DIFF
--- a/ExcelViewer/mainwindow.cpp
+++ b/ExcelViewer/mainwindow.cpp
@@ -16,9 +16,6 @@
 
 using namespace QXlsx;
 
-// Hard-coded QXlsx version string (based on the library you are using)
-// static const char *QXLSX_VERSION = "1.5.0";
-
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
 {

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(QXlsx
-    VERSION 1.5.0
+    VERSION 1.5.1
     LANGUAGES CXX
 )
 

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -158,6 +158,12 @@ target_compile_definitions(QXlsx PRIVATE
     QT_DISABLE_DEPRECATED_BEFORE=0x060600
 )
 
+if(MSVC)
+    # Disable strict MSVC compliance mode to prevent build errors 
+    # caused by standard library ('stdext') changes in newer MSVC compilers with older Qt headers.
+    target_compile_options(QXlsx PRIVATE /permissive)
+endif()
+
 if (NOT WIN32)
     # Strict iterators can't be used on Windows, they lead to a link error
     # when application code iterates over a QVector<QPoint> for instance, unless

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -158,10 +158,13 @@ target_compile_definitions(QXlsx PRIVATE
     QT_DISABLE_DEPRECATED_BEFORE=0x060600
 )
 
+
 if(MSVC)
-    # Fix 'stdext' errors by allowing mismatch between newer MSVC toolset and older Qt/STL headers
-    target_compile_definitions(QXlsx PRIVATE _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
+    # SHELL: forces CMake to place /permissive at the very end of the argument list,
+    # overriding any automatically appended /permissive- flags.
+    target_compile_options(QXlsx PRIVATE "SHELL:/permissive")
 endif()
+
 
 if (NOT WIN32)
     # Strict iterators can't be used on Windows, they lead to a link error

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -159,9 +159,8 @@ target_compile_definitions(QXlsx PRIVATE
 )
 
 if(MSVC)
-    # Disable strict MSVC compliance mode to prevent build errors 
-    # caused by standard library ('stdext') changes in newer MSVC compilers with older Qt headers.
-    target_compile_options(QXlsx PRIVATE /permissive)
+    # Fix 'stdext' errors by allowing mismatch between newer MSVC toolset and older Qt/STL headers
+    target_compile_definitions(QXlsx PRIVATE _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
 endif()
 
 if (NOT WIN32)

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -7,6 +7,12 @@ project(QXlsx
     LANGUAGES CXX
 )
 
+if(MSVC)
+    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_AUTOMOC ON)

--- a/QXlsx/CMakeLists.txt
+++ b/QXlsx/CMakeLists.txt
@@ -7,12 +7,6 @@ project(QXlsx
     LANGUAGES CXX
 )
 
-if(MSVC)
-    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-    string(REPLACE "/permissive-" "/permissive" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-endif()
-
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_AUTOMOC ON)

--- a/QXlsx/QXlsx.pri
+++ b/QXlsx/QXlsx.pri
@@ -5,8 +5,17 @@
 QT += core
 QT += gui-private
 
-# TODO: Define your C++ version. c++14, c++17, etc.
-CONFIG += c++11
+# Define your C++ version.
+# Safe method using built-in variables without brackets
+lessThan(QT_MAJOR_VERSION, 6) {
+    # Set C++11 for Qt 5 (5.7 or higher version)
+    CONFIG += c++11
+    message("Qt 5 detected: Setting C++ standard to C++11")
+} else {
+    # Set C++17 for Qt 6
+    CONFIG += c++17
+    message("Qt 6 detected: Setting C++ standard to C++17")
+}
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings

--- a/QXlsx/QXlsx.pro
+++ b/QXlsx/QXlsx.pro
@@ -29,10 +29,4 @@ QXLSX_HEADERPATH=$$PWD/header/
 QXLSX_SOURCEPATH=$$PWD/source/
 include($$PWD/QXlsx.pri)
 
-HEADERS += \
-    header/xlsxreadsax.h
-
-SOURCES += \
-    source/xlsxreadsax.cpp
-
 

--- a/QXlsx/header/xlsxglobal.h
+++ b/QXlsx/header/xlsxglobal.h
@@ -3,6 +3,10 @@
 #ifndef XLSXGLOBAL_H
 #define XLSXGLOBAL_H
 
+#if defined(_MSC_VER) && !defined(stdext)
+#define stdext ::std
+#endif
+
 #include <cstdio>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
This pull request updates build configuration and compatibility for the QXlsx project, with a focus on improving C++ standard handling, supporting MSVC builds, and updating versioning. The changes enhance cross-platform compatibility and modernize the build process.

**Build system and compatibility improvements:**

* Updated the project version from `1.5.0` to `1.5.1` in `QXlsx/CMakeLists.txt` to reflect the latest changes.
* Added logic in `QXlsx/QXlsx.pri` to automatically set the C++ standard: uses C++11 for Qt 5 and C++17 for Qt 6, improving compatibility and modernization.
* Added a conditional in `QXlsx/CMakeLists.txt` to force the `/permissive` flag for MSVC builds, ensuring compatibility with certain C++ standards and suppressing related build errors.
* Added a macro in `QXlsx/header/xlsxglobal.h` to define `stdext` for MSVC compilers, improving compatibility with Microsoft's STL extensions.

**Code and configuration cleanup:**

* Removed unused hard-coded QXlsx version string from `ExcelViewer/mainwindow.cpp` and cleaned up redundant header/source references in `QXlsx/QXlsx.pro`. [[1]](diffhunk://#diff-d3db8c669b81551737813cf07bef4553a59c748455e4eb276c83c7ad980502baL19-L21) [[2]](diffhunk://#diff-4216e33c9c7797cd4e6027c21ad14796ced2890f346a6b4c560d0c9fd75cab05L32-L37)